### PR TITLE
Add option to forego real entities

### DIFF
--- a/default_settings.lua
+++ b/default_settings.lua
@@ -27,6 +27,7 @@ local settings = {
 	enable_cyclic_mode = true,
 	drop_on_routing_fail = false,
 	delete_item_on_clearobject = true,
+	use_real_entities = true,
 }
 
 pipeworks.toggles = {}

--- a/luaentity.lua
+++ b/luaentity.lua
@@ -73,31 +73,43 @@ local function get_blockpos(pos)
 	        z = math.floor(pos.z / 16)}
 end
 
-local active_blocks = {} -- These only contain active blocks near players (i.e., not forceloaded ones)
+local move_entities_globalstep_part1
+local is_active
 
-local move_entities_globalstep_part1 = function(dtime)
-	local active_block_range = tonumber(minetest.settings:get("active_block_range")) or 2
-	local new_active_blocks = {}
-	for _, player in ipairs(minetest.get_connected_players()) do
-		local blockpos = get_blockpos(player:get_pos())
-		local minp = vector.subtract(blockpos, active_block_range)
-		local maxp = vector.add(blockpos, active_block_range)
+if pipeworks.use_real_entities then
+	local active_blocks = {} -- These only contain active blocks near players (i.e., not forceloaded ones)
 
-		for x = minp.x, maxp.x do
-		for y = minp.y, maxp.y do
-		for z = minp.z, maxp.z do
-			local pos = {x = x, y = y, z = z}
-			new_active_blocks[minetest.hash_node_position(pos)] = pos
+	move_entities_globalstep_part1 = function(dtime)
+		local active_block_range = tonumber(minetest.settings:get("active_block_range")) or 2
+		local new_active_blocks = {}
+		for _, player in ipairs(minetest.get_connected_players()) do
+			local blockpos = get_blockpos(player:get_pos())
+			local minp = vector.subtract(blockpos, active_block_range)
+			local maxp = vector.add(blockpos, active_block_range)
+
+			for x = minp.x, maxp.x do
+			for y = minp.y, maxp.y do
+			for z = minp.z, maxp.z do
+				local pos = {x = x, y = y, z = z}
+				new_active_blocks[minetest.hash_node_position(pos)] = pos
+			end
+			end
+			end
 		end
-		end
-		end
+		active_blocks = new_active_blocks
+		-- todo: callbacks on block load/unload
 	end
-	active_blocks = new_active_blocks
-	-- todo: callbacks on block load/unload
-end
 
-local function is_active(pos)
-	return active_blocks[minetest.hash_node_position(get_blockpos(pos))] ~= nil
+	is_active = function(pos)
+		return active_blocks[minetest.hash_node_position(get_blockpos(pos))] ~= nil
+	end
+else
+	move_entities_globalstep_part1 = function()
+	end
+
+	is_active = function()
+		return false
+	end
 end
 
 local entitydef_default = {

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -75,3 +75,6 @@ pipeworks_drop_on_routing_fail (Drop On Routing Fail) bool false
 
 #Delete item on clearobject.
 pipeworks_delete_item_on_clearobject (Delete Item On Clearobject) bool true
+
+#Use real visible entities in tubes within active areas.
+pipeworks_use_real_entities (Use real entities) bool true


### PR DESCRIPTION
It seems like people sometimes have trouble with the performance of Pipeworks. Since the tube item entities are essentially decorative\*, I tried removing them. Doing this was quite simple, since Pipeworks can already handle luaentities without real entities bound to them. This PR simply gives the option of treating all mapblocks as inactive.

To test, I put 19 or so items into a loop of 9 segments. With real entities turned on, the average time per step taken by Pipeworks was about 920 microseconds, according to the profiler. With real entities turned off, the average time fell to about 660 microseconds. Without the entities, the server also will not need to send as many updates to the client, which was not measured by this benchmark.

When using real entities, it seems that a lot of the time is spent in `move_entities_globalstep_part1` updating the active blocks. Therefore, turning off real entities should give a performance boost even when no tube entities are spawned. Perhaps the checking of block activeness could be changed to use `minetest.compare_block_status` when available. The downside is that this would return true for forceloaded blocks, which could lead to more real entities being spawned if there are tubes in forceloaded blocks.

---

\* I believe TechPack's TubeLib is supposed to be a faster alternative to Pipeworks, and it goes without the entities.