### PR TITLE
Add option for opaque tubes

### DIFF
--- a/decorative_tubes.lua
+++ b/decorative_tubes.lua
@@ -42,9 +42,6 @@ local pane_box = {
 	}
 }
 
-local texture_alpha_mode = minetest.features.use_texture_alpha_string_modes
-	and "clip" or true
-
 minetest.register_node("pipeworks:steel_pane_embedded_tube", {
 	drawtype = "nodebox",
 	description = S("Airtight panel embedded tube"),
@@ -55,7 +52,7 @@ minetest.register_node("pipeworks:steel_pane_embedded_tube", {
 		"pipeworks_pane_embedded_tube_sides.png",
 		"pipeworks_pane_embedded_tube_ends.png", "pipeworks_pane_embedded_tube_ends.png",
 		},
-	use_texture_alpha = texture_alpha_mode,
+	use_texture_alpha = pipeworks.tube_texture_alpha_mode,
 	node_box = pane_box,
 	selection_box = pane_box,
 	collision_box = pane_box,

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -5,7 +5,6 @@ local prefix = "pipeworks_"
 local settings = {
 	enable_pipes = true,
 	enable_lowpoly = false,
-	enable_opaque_tubes = false,
 	enable_autocrafter = true,
 	enable_deployer = true,
 	enable_dispenser = true,
@@ -28,6 +27,7 @@ local settings = {
 	enable_cyclic_mode = true,
 	drop_on_routing_fail = false,
 	delete_item_on_clearobject = true,
+	tube_transparency = "auto",
 	use_real_entities = true,
 }
 
@@ -69,6 +69,10 @@ for name, value in pairs(settings) do
 			pipeworks[name] = value
 		end
 	else
-		pipeworks[name] = value
+		pipeworks[name] = minetest.settings:get(prefix..name) or value
 	end
+end
+
+if pipeworks.tube_transparency == "auto" then
+	pipeworks.tube_transparency = pipeworks.use_real_entities and "transparent" or "opaque"
 end

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -5,6 +5,7 @@ local prefix = "pipeworks_"
 local settings = {
 	enable_pipes = true,
 	enable_lowpoly = false,
+	enable_opaque_tubes = false,
 	enable_autocrafter = true,
 	enable_deployer = true,
 	enable_dispenser = true,

--- a/init.lua
+++ b/init.lua
@@ -58,6 +58,14 @@ pipeworks.button_on    = {text="", texture="pipeworks_button_on.png",  addopts="
 pipeworks.button_base  = "image_button[0,4.3;1,0.6"
 pipeworks.button_label = "label[0.9,4.31;"..S("Allow splitting incoming stacks from tubes").."]"
 
+if pipeworks.enable_opaque_tubes then
+	pipeworks.tube_texture_alpha_mode = minetest.features.use_texture_alpha_string_modes and "opaque" or false
+else
+	-- This will remove any semi-transparent pixels
+	-- because that is still buggy in Minetest, force this as default
+	pipeworks.tube_texture_alpha_mode = minetest.features.use_texture_alpha_string_modes and "clip" or true
+end
+
 -- Helper functions
 
 function pipeworks.fix_image_names(table, replacement)

--- a/init.lua
+++ b/init.lua
@@ -58,7 +58,7 @@ pipeworks.button_on    = {text="", texture="pipeworks_button_on.png",  addopts="
 pipeworks.button_base  = "image_button[0,4.3;1,0.6"
 pipeworks.button_label = "label[0.9,4.31;"..S("Allow splitting incoming stacks from tubes").."]"
 
-if pipeworks.enable_opaque_tubes then
+if pipeworks.tube_transparency == "opaque" then
 	pipeworks.tube_texture_alpha_mode = minetest.features.use_texture_alpha_string_modes and "opaque" or false
 else
 	-- This will remove any semi-transparent pixels

--- a/lua_tube.lua
+++ b/lua_tube.lua
@@ -821,9 +821,6 @@ local tiles_on_off = {
 	R270 = "^(pipeworks_lua_tube_port_%s.png^[transformR270)"
 }
 
-local texture_alpha_mode = minetest.features.use_texture_alpha_string_modes
-	and "clip" or true
-
 for red    = 0, 1 do -- 0 = off  1 = on
 for blue   = 0, 1 do
 for yellow = 0, 1 do
@@ -908,7 +905,7 @@ for white  = 0, 1 do
 		description = "Lua controlled Tube",
 		drawtype = "nodebox",
 		tiles = tiles,
-		use_texture_alpha = texture_alpha_mode,
+		use_texture_alpha = pipeworks.tube_texture_alpha_mode,
 		paramtype = "light",
 		is_ground_content = false,
 		groups = groups,
@@ -1019,7 +1016,7 @@ tiles_burnt[4] = tiles_burnt[4].."^(pipeworks_lua_tube_port_burnt.png^[transform
 minetest.register_node(BASENAME .. "_burnt", {
 	drawtype = "nodebox",
 	tiles = tiles_burnt,
-	use_texture_alpha = texture_alpha_mode,
+	use_texture_alpha = pipeworks.tube_texture_alpha_mode,
 	is_burnt = true,
 	paramtype = "light",
 	is_ground_content = false,

--- a/routing_tubes.lua
+++ b/routing_tubes.lua
@@ -139,15 +139,12 @@ if pipeworks.enable_crossing_tube then
 	})
 end
 
-local texture_alpha_mode = minetest.features.use_texture_alpha_string_modes
-	and "clip" or true
-
 if pipeworks.enable_one_way_tube then
 	minetest.register_node("pipeworks:one_way_tube", {
 		description = S("One way tube"),
 		tiles = {"pipeworks_one_way_tube_top.png", "pipeworks_one_way_tube_top.png", "pipeworks_one_way_tube_output.png",
 			"pipeworks_one_way_tube_input.png", "pipeworks_one_way_tube_side.png", "pipeworks_one_way_tube_top.png"},
-		use_texture_alpha = texture_alpha_mode,
+		use_texture_alpha = pipeworks.tube_texture_alpha_mode,
 		paramtype2 = "facedir",
 		drawtype = "nodebox",
 		paramtype = "light",

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,9 +1,6 @@
 #Enable pipes.
 pipeworks_enable_pipes (Enable Pipes) bool true
 
-#Enables concealment of tube contents using black texture backgrounds.
-pipeworks_enable_opaque_tubes (Enable Opaque Tubes) bool false
-
 #Enable autocrafter.
 pipeworks_enable_autocrafter (Enable Autocrafter) bool true
 
@@ -78,6 +75,12 @@ pipeworks_drop_on_routing_fail (Drop On Routing Fail) bool false
 
 #Delete item on clearobject.
 pipeworks_delete_item_on_clearobject (Delete Item On Clearobject) bool true
+
+#Tube transparency:
+#- transparent: Contents of tubes are visible.
+#- opaque: Contents of tubes are hidden by black walls.
+#- auto: Tubes are transparent only if the use of real visible entities for tube items is enabled.
+pipeworks_tube_transparency (Tube Transparency) enum auto transparent,opaque,auto
 
 #Use real visible entities in tubes within active areas.
 pipeworks_use_real_entities (Use real entities) bool true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,6 +1,9 @@
 #Enable pipes.
 pipeworks_enable_pipes (Enable Pipes) bool true
 
+#Enables concealment of tube contents using black texture backgrounds.
+pipeworks_enable_opaque_tubes (Enable Opaque Tubes) bool false
+
 #Enable autocrafter.
 pipeworks_enable_autocrafter (Enable Autocrafter) bool true
 

--- a/tube_registration.lua
+++ b/tube_registration.lua
@@ -26,11 +26,6 @@ local texture_mt = {
 	end
 }
 
--- This will remove any semi-transparent pixels
--- because that is still buggy in Minetest, force this as default
-local texture_alpha_mode = minetest.features.use_texture_alpha_string_modes
-	and "clip" or true
-
 local register_one_tube = function(name, tname, dropname, desc, plain, noctrs, ends, short, inv, special, connects, style)
 	noctrs = noctrs or default_noctrs
 	setmetatable(noctrs, texture_mt)
@@ -87,7 +82,7 @@ local register_one_tube = function(name, tname, dropname, desc, plain, noctrs, e
 		description = tubedesc,
 		drawtype = "nodebox",
 		tiles = outimgs,
-		use_texture_alpha = texture_alpha_mode,
+		use_texture_alpha = pipeworks.tube_texture_alpha_mode,
 		sunlight_propagates = true,
 		inventory_image = iimg,
 		wield_image = iimg,


### PR DESCRIPTION
This adds an option for giving tubes solid black backgrounds. It is meant to be enabled along with the option from #26. The textures don't look that good, but without custom opaque tube textures, this is to be expected.