### PR TITLE
Add configurable globalstep interval

### DIFF
--- a/default_settings.lua
+++ b/default_settings.lua
@@ -28,6 +28,7 @@ local settings = {
 	drop_on_routing_fail = false,
 	delete_item_on_clearobject = true,
 	use_real_entities = true,
+	globalstep_interval = 0,
 }
 
 pipeworks.toggles = {}
@@ -63,10 +64,9 @@ pipeworks.toggles.finite_water = nil
 for name, value in pairs(settings) do
 	local setting_type = type(value)
 	if setting_type == "boolean" then
-		pipeworks[name] = minetest.settings:get_bool(prefix..name)
-		if pipeworks[name] == nil then
-			pipeworks[name] = value
-		end
+		pipeworks[name] = minetest.settings:get_bool(prefix..name, value)
+	elseif setting_type == "number" then
+		pipeworks[name] = tonumber(minetest.settings:get(prefix..name) or value)
 	else
 		pipeworks[name] = value
 	end

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -28,7 +28,7 @@ local settings = {
 	drop_on_routing_fail = false,
 	delete_item_on_clearobject = true,
 	use_real_entities = true,
-	globalstep_interval = 0,
+	entity_update_interval = 0,
 }
 
 pipeworks.toggles = {}

--- a/init.lua
+++ b/init.lua
@@ -32,8 +32,8 @@ end
 if pipeworks.toggles.pipe_mode == "pressure" then
 	minetest.log("warning", "pipeworks pressure logic mode comes with caveats and differences in behaviour, you have been warned!")
 end
-if pipeworks.globalstep_interval >= 0.2 and pipeworks.enable_accelerator_tube then
-	minetest.log("warning", "pipeworks accelerator tubes will not entirely work with a globalstep interval 0.2 or above.")
+if pipeworks.entity_update_interval >= 0.2 and pipeworks.enable_accelerator_tube then
+	minetest.log("warning", "pipeworks accelerator tubes will not entirely work with an entity update interval 0.2 or above.")
 end
 
 -- Random variables

--- a/init.lua
+++ b/init.lua
@@ -32,6 +32,9 @@ end
 if pipeworks.toggles.pipe_mode == "pressure" then
 	minetest.log("warning", "pipeworks pressure logic mode comes with caveats and differences in behaviour, you have been warned!")
 end
+if pipeworks.globalstep_interval >= 0.2 and pipeworks.enable_accelerator_tube then
+	minetest.log("warning", "pipeworks accelerator tubes will not entirely work with a globalstep interval 0.2 or above.")
+end
 
 -- Random variables
 

--- a/luaentity.lua
+++ b/luaentity.lua
@@ -383,7 +383,7 @@ local move_entities_globalstep_part2 = function(dtime)
 end
 
 -- dtime after which there is an update (or skip).
-local dtime_threshold = pipeworks.globalstep_interval
+local dtime_threshold = pipeworks.entity_update_interval
 -- Accumulated dtime since last update (or skip).
 local dtime_accum = 0
 -- Delayed dtime accumulated due to skipped updates.
@@ -410,8 +410,8 @@ minetest.register_globalstep(function(dtime)
 		dtime_delayed = 0
 	end
 
-	-- Tune the threshold so that the average interval is pipeworks.globalstep_interval.
-	dtime_threshold = math.max(dtime_threshold + (pipeworks.globalstep_interval - dtime_accum) / 10, 0)
+	-- Tune the threshold so that the average interval is pipeworks.entity_update_interval.
+	dtime_threshold = math.max(dtime_threshold + (pipeworks.entity_update_interval - dtime_accum) / 10, 0)
 
 	dtime_accum = 0
 end)

--- a/luaentity.lua
+++ b/luaentity.lua
@@ -382,13 +382,36 @@ local move_entities_globalstep_part2 = function(dtime)
 	end
 end
 
-local handle_active_blocks_timer = 0.1
+-- dtime after which there is an update (or skip).
+local dtime_threshold = pipeworks.globalstep_interval
+-- Accumulated dtime since last update (or skip).
+local dtime_accum = 0
+-- Delayed dtime accumulated due to skipped updates.
+local dtime_delayed = 0
+local skip_update = false
 
 minetest.register_globalstep(function(dtime)
-	handle_active_blocks_timer = handle_active_blocks_timer + dtime
-	if dtime < 0.2 or handle_active_blocks_timer >= (dtime * 3) then
-		handle_active_blocks_timer = 0.1
-		move_entities_globalstep_part1(dtime)
-		move_entities_globalstep_part2(dtime)
+	if dtime >= 0.2 and dtime_delayed < 1 then
+		-- Reduce activity when the server is lagging.
+		skip_update = true
 	end
+
+	dtime_accum = dtime_accum + dtime
+	if dtime_accum < dtime_threshold then
+		return
+	end
+
+	if skip_update then
+		dtime_delayed = dtime_delayed + dtime_accum
+		skip_update = false
+	else
+		move_entities_globalstep_part1(dtime_accum + dtime_delayed)
+		move_entities_globalstep_part2(dtime_accum + dtime_delayed)
+		dtime_delayed = 0
+	end
+
+	-- Tune the threshold so that the average interval is pipeworks.globalstep_interval.
+	dtime_threshold = math.max(dtime_threshold + (pipeworks.globalstep_interval - dtime_accum) / 10, 0)
+
+	dtime_accum = 0
 end)

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -78,4 +78,9 @@ pipeworks_delete_item_on_clearobject (Delete Item On Clearobject) bool true
 
 #Use real visible entities in tubes within active areas.
 #When disabled, tubes are made opaque.
-pipeworks_use_real_entities (Use real entities) bool true
+pipeworks_use_real_entities (Use Real Entities) bool true
+
+#Target interval between tube entity steps.
+#A high value may cause issues with tube entity visuals.
+#A value 0.2 or above may cause issues with accelerator tubes.
+pipeworks_globalstep_interval (Globalstep Interval) float 0 0 1

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -83,4 +83,4 @@ pipeworks_use_real_entities (Use Real Entities) bool true
 #Target interval between tube entity steps.
 #A high value may cause issues with tube entity visuals.
 #A value 0.2 or above may cause issues with accelerator tubes.
-pipeworks_globalstep_interval (Globalstep Interval) float 0 0 1
+pipeworks_globalstep_interval (Globalstep Interval) float 0 0 0.8

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -83,4 +83,4 @@ pipeworks_use_real_entities (Use Real Entities) bool true
 #Target interval between tube entity steps.
 #A high value may cause issues with tube entity visuals.
 #A value 0.2 or above may cause issues with accelerator tubes.
-pipeworks_globalstep_interval (Globalstep Interval) float 0 0 0.8
+pipeworks_entity_update_interval (Entity Update Interval) float 0 0 0.8


### PR DESCRIPTION
It is not always necessary to update tube entities every step, especially when real entities are not being used. This PR gives people the option of spreading out entity updates. The new code can handle precise intervals even with granular server steps, since the code dynamically adjusts to control the average interval. You can try it yourself by printing out `dtime_accum` every update.

I have found that the highest viable interval is 0.19. (With a server step of 0.09, this means 8/9 update intervals will be 0.18 and every ninth will be 0.27.) Above 0.19, accelerated entities move faster than the globalstep can manage.

Tube entities decelerate at different rates depending on the dtime, but I think that's a separate issue. I believe it could already manifest e.g. in singleplayer vs multiplayer.