### PR TITLE
Store teleport tube DB in mod storage

### DIFF
--- a/README
+++ b/README
@@ -20,3 +20,7 @@ This mod is a work in progress.
 
 Please note that owing to the nature of this mod, I have opted to use 64px 
 textures.  Anything less just looks terrible.
+
+The teleport tube database used to kept in a file named 'teleport_tubes'.
+The database is now kept in mod storage. The migration from 'teleport_tubes' is
+automatic. The old file is then kept around but is not used at all.

--- a/init.lua
+++ b/init.lua
@@ -128,7 +128,7 @@ function pipeworks.replace_name(tbl,tr,name)
 end
 
 pipeworks.logger = function(msg)
-	print("[pipeworks] "..msg)
+	minetest.log("action", "[pipeworks] "..msg)
 end
 
 -------------------------------------------

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -71,9 +71,15 @@ local function read_tube_db()
 		local file_content = file:read("*all")
 		io.close(file)
 
-		local backup_filename = filename .. ".bak"
 		pipeworks.logger("Moving teleport tube DB to mod storage from " .. filename)
+		local backup_filename = filename .. ".bak"
 		pipeworks.logger("Backing up old file as " .. backup_filename)
+		local backup_file = io.open(backup_filename, "r")
+		if backup_file then
+			io.close(backup_file)
+			error("Cannot back up teleport tube DB file " ..
+				"as a file already exists at " .. backup_filename)
+		end
 		assert(os.rename(filename, backup_filename))
 
 		if file_content and file_content ~= "" then

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -71,6 +71,8 @@ local function read_tube_db()
 		local file_content = file:read("*all")
 		io.close(file)
 
+		pipeworks.logger("Moving teleport tube DB into mod storage from " .. filename)
+
 		if file_content and file_content ~= "" then
 			tp_tube_db = minetest.deserialize(file_content)
 		else

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -55,7 +55,7 @@ local function read_tube_db()
 			if tonumber(key) then
 				tp_tube_db[key] = minetest.deserialize(val)
 			elseif key == "version" then
-				tp_tube_db[key] = tonumber(val)
+				tp_tube_db.version = tonumber(val)
 			else
 				error("Unknown field in teleport tube DB: " .. key)
 			end

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -71,17 +71,6 @@ local function read_tube_db()
 		local file_content = file:read("*all")
 		io.close(file)
 
-		pipeworks.logger("Moving teleport tube DB to mod storage from " .. filename)
-		local backup_filename = filename .. ".bak"
-		pipeworks.logger("Backing up old file as " .. backup_filename)
-		local backup_file = io.open(backup_filename, "r")
-		if backup_file then
-			io.close(backup_file)
-			error("Cannot back up teleport tube DB file " ..
-				"as a file already exists at " .. backup_filename)
-		end
-		assert(os.rename(filename, backup_filename))
-
 		if file_content and file_content ~= "" then
 			tp_tube_db = minetest.deserialize(file_content)
 		else


### PR DESCRIPTION
Advantages:
* Not limited by the maximum number of constants in `minetest.deserialize` (Fixes https://github.com/mt-mods/pipeworks/issues/39).
* Changes to individual entries can be committed without re-serializing the entire database, provided Minetest 5.5 or later is used.

If the mod storage is not initialized and there is an old `teleport_tubes` file present, the database is initially read from this file.