### PR TITLE
check if machine is protected before trying to break/place a node

### DIFF
--- a/wielder.lua
+++ b/wielder.lua
@@ -336,6 +336,14 @@ if pipeworks.enable_node_breaker then
 		masquerade_as_owner = true,
 		sneak = false,
 		act = function(virtplayer, pointed_thing)
+			local player_name = virtplayer:get_player_name()
+			if (
+				minetest.is_protected(pointed_thing.above, player_name) or
+				minetest.is_protected(pointed_thing.under, player_name)
+			) then
+				return
+			end
+
 			--local dname = "nodebreaker.act() "
 			local wieldstack = virtplayer:get_wielded_item()
 			local oldwieldstack = ItemStack(wieldstack)
@@ -427,6 +435,14 @@ if pipeworks.enable_deployer then
 		masquerade_as_owner = true,
 		sneak = false,
 		act = function(virtplayer, pointed_thing)
+			local player_name = virtplayer:get_player_name()
+			if (
+				minetest.is_protected(pointed_thing.above, player_name) or
+				minetest.is_protected(pointed_thing.under, player_name)
+			) then
+				return
+			end
+
 			local wieldstack = virtplayer:get_wielded_item()
 			virtplayer:set_wielded_item((minetest.registered_items[wieldstack:get_name()] or {on_place=minetest.item_place}).on_place(wieldstack, virtplayer, pointed_thing) or wieldstack)
 		end,

--- a/wielder.lua
+++ b/wielder.lua
@@ -336,11 +336,7 @@ if pipeworks.enable_node_breaker then
 		masquerade_as_owner = true,
 		sneak = false,
 		act = function(virtplayer, pointed_thing)
-			local player_name = virtplayer:get_player_name()
-			if (
-				minetest.is_protected(pointed_thing.above, player_name) or
-				minetest.is_protected(pointed_thing.under, player_name)
-			) then
+			if minetest.is_protected(vector.add(virtplayer:get_pos(), assumed_eye_pos), virtplayer:get_player_name()) then
 				return
 			end
 
@@ -435,11 +431,7 @@ if pipeworks.enable_deployer then
 		masquerade_as_owner = true,
 		sneak = false,
 		act = function(virtplayer, pointed_thing)
-			local player_name = virtplayer:get_player_name()
-			if (
-				minetest.is_protected(pointed_thing.above, player_name) or
-				minetest.is_protected(pointed_thing.under, player_name)
-			) then
+			if minetest.is_protected(vector.add(virtplayer:get_pos(), assumed_eye_pos), virtplayer:get_player_name()) then
 				return
 			end
 


### PR DESCRIPTION
this is slight modification to #42.

to recap:

so as not to trigger protection violations. currently, there is a problem when

1. a player puts down a node breaker in an unprotected area
2. another player protects the area
3. nodes continue to be broken
4. protection violations occur, possibly w/ penalties on the violating player, who can no-longer even dismantle their machine. 
