### PR TITLE
Use sane default i3 inventory settings when missing

### DIFF
--- a/common.lua
+++ b/common.lua
@@ -149,7 +149,8 @@ function fs_helpers.get_inv(y)
 		local inv_x = i3.settings.legacy_inventory and 0.75 or 0.22
 		local inv_y = (y + 0.4) or 6.9
 		local size, spacing = 1, 0.1
-		local hotbar_len = i3.settings.hotbar_len
+		local hotbar_len = i3.settings.hotbar_len or (i3.settings.legacy_inventory and 8 or 9)
+		local inv_size = i3.settings.inv_size or (hotbar_len * 4)
 
 		table.insert(fs, "style_type[box;colors=#77777710,#77777710,#777,#777]")
 
@@ -162,13 +163,13 @@ function fs_helpers.get_inv(y)
 
 		table.insert(fs, "style_type[box;colors=#666]")
 		for i=0, 2 do
-			for j=0, (i3.settings.legacy_inventory and 7 or 8) do
+			for j=0, hotbar_len - 1 do
 				table.insert(fs, "box["..0.2+(j*0.1)+(j*size)..","..(inv_y+size+spacing+0.05)+(i*0.1)+(i*size)..";"..size..","..size..";]")
 			end
 		end
 
 		table.insert(fs, "style_type[list;size="..size..";spacing="..spacing.."]")
-		table.insert(fs, "list[current_player;main;"..inv_x..","..(inv_y + 1.15)..";"..hotbar_len..","..(i3.settings.inv_size / hotbar_len)..";"..hotbar_len.."]")
+		table.insert(fs, "list[current_player;main;"..inv_x..","..(inv_y + 1.15)..";"..hotbar_len..","..(inv_size / hotbar_len)..";"..hotbar_len.."]")
 	else
 		table.insert(fs, "list[current_player;main;0.22,"..y..";8,4;]")
 	end


### PR DESCRIPTION
 - Both `i3.settings.hotbar_len` and `i3.settings.inv_size` were removed in `i3`'s commit `75fddf7` because they are now per-player settings in `I3`
 - This just guesses sane defaults when the settings are not present to avoid a few nils and allow the game to continue without addressing the fact that these settings are now per-player. If there is a mixture of player settings (ie some with inventory sizes of 9, and some with 8), oddness will ensue despite the lack of crash.
- Note: Left in the removed settings for now to make this drop-in safe ; they should be removed at some point.

Tested in my soup where `i3.settings.legacy_inventory` defaults to true ; The Stackwise Filter-Injector has an inventory 8-wide.

Given the referenced commit above (search for `hotbar_len`) and the changes here, I think I've done enough testing; let me know if more is desired. I've run out of time for now.

Luacheck tells me it's all clean.

EDIT: Punctuation and spacing