### PR TITLE
log when items teleport through tubes

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -84,3 +84,6 @@ pipeworks_use_real_entities (Use Real Entities) bool true
 #A high value may cause issues with tube entity visuals.
 #A value 0.2 or above may cause issues with accelerator tubes.
 pipeworks_entity_update_interval (Entity Update Interval) float 0 0 0.8
+
+# if set to true, items passing through teleport tubes will log log where they came from and where they went.
+pipeworks_log_teleport_tubes (Log Teleport Tubes) bool false

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -233,7 +233,8 @@ local function can_go(pos, node, velocity, stack)
 	velocity.x = 0
 	velocity.y = 0
 	velocity.z = 0
-	local channel = minetest.get_meta(pos):get_string("channel")
+	local src_meta = minetest.get_meta(pos)
+	local channel = src_meta:get_string("channel")
 	if channel == "" then
 		return {}
 	end
@@ -242,6 +243,12 @@ local function can_go(pos, node, velocity, stack)
 		return {}
 	end
 	local target = receivers[math.random(1, #receivers)]
+	local src_owner = src_meta:get_string("owner")
+	local dst_meta = minetest.get_meta(pos)
+	local dst_owner = dst_meta:get_string("owner")
+	minetest.log("action", string.format("[pipeworks] %s teleported from %s (owner=%s) to %s (owner=%s) via %s",
+		stack:to_string(), minetest.pos_to_string(pos), src_owner, minetest.pos_to_string(target), dst_owner, channel
+	))
 	pos.x = target.x
 	pos.y = target.y
 	pos.z = target.z

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -243,10 +243,10 @@ local function can_go(pos, node, velocity, stack)
 		return {}
 	end
 	local target = receivers[math.random(1, #receivers)]
-	local src_owner = src_meta:get_string("owner")
-	local dst_meta = minetest.get_meta(pos)
-	local dst_owner = dst_meta:get_string("owner")
 	if minetest.settings:get_bool("pipeworks_log_teleport_tubes", false) then
+		local src_owner = src_meta:get_string("owner")
+		local dst_meta = minetest.get_meta(pos)
+		local dst_owner = dst_meta:get_string("owner")
 		minetest.log("action", string.format("[pipeworks] %s teleported from %s (owner=%s) to %s (owner=%s) via %s",
 			stack:to_string(), minetest.pos_to_string(pos), src_owner, minetest.pos_to_string(target), dst_owner, channel
 		))

--- a/teleport_tube.lua
+++ b/teleport_tube.lua
@@ -246,9 +246,11 @@ local function can_go(pos, node, velocity, stack)
 	local src_owner = src_meta:get_string("owner")
 	local dst_meta = minetest.get_meta(pos)
 	local dst_owner = dst_meta:get_string("owner")
-	minetest.log("action", string.format("[pipeworks] %s teleported from %s (owner=%s) to %s (owner=%s) via %s",
-		stack:to_string(), minetest.pos_to_string(pos), src_owner, minetest.pos_to_string(target), dst_owner, channel
-	))
+	if minetest.settings:get_bool("pipeworks_log_teleport_tubes", false) then
+		minetest.log("action", string.format("[pipeworks] %s teleported from %s (owner=%s) to %s (owner=%s) via %s",
+			stack:to_string(), minetest.pos_to_string(pos), src_owner, minetest.pos_to_string(target), dst_owner, channel
+		))
+	end
 	pos.x = target.x
 	pos.y = target.y
 	pos.z = target.z


### PR DESCRIPTION
i'm trying to figure out where a player's items went after they were passed through a teleport tube, but didn't arrive at the destination. this PR adds a simple log to aid in resolving future issues. 