### PR TITLE
Fix autocrafter destroying replacement items

### DIFF
--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -35,17 +35,13 @@ end
 
 local function autocraft(inventory, craft)
 	if not craft then return false end
-	local output = craft.output.item
-
-	-- check if we have enough room in dst
-	if not inventory:room_for_item("dst", output) then	return false end
-	local consumption = craft.consumption
-	local inv_index = count_index(inventory:get_list("src"))
 	-- check if we have enough material available
-	for itemname, number in pairs(consumption) do
+	local inv_index = count_index(inventory:get_list("src"))
+	for itemname, number in pairs(craft.consumption) do
 		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
 	end
 	-- check if output and all replacements fit in dst
+	local output = craft.output.item
 	local out_items = count_index(craft.decremented_input.items)
 	out_items[output:get_name()] = (out_items[output:get_name()] or 0) + output:get_count()
 	local empty_count = 0
@@ -68,12 +64,11 @@ local function autocraft(inventory, craft)
 		return false
 	end
 	-- consume material
-	for itemname, number in pairs(consumption) do
+	for itemname, number in pairs(craft.consumption) do
 		for _ = 1, number do -- We have to do that since remove_item does not work if count > stack_max
 			inventory:remove_item("src", ItemStack(itemname))
 		end
 	end
-
 	-- craft the result into the dst inventory and add any "replacements" as well
 	inventory:add_item("dst", output)
 	for i = 1, 9 do

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -35,15 +35,37 @@ end
 
 local function autocraft(inventory, craft)
 	if not craft then return false end
-	local output_item = craft.output.item
+	local output = craft.output.item
 
 	-- check if we have enough room in dst
-	if not inventory:room_for_item("dst", output_item) then	return false end
+	if not inventory:room_for_item("dst", output) then	return false end
 	local consumption = craft.consumption
 	local inv_index = count_index(inventory:get_list("src"))
 	-- check if we have enough material available
 	for itemname, number in pairs(consumption) do
 		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
+	end
+	-- check if output and all replacements fit in dst
+	local out_items = count_index(craft.decremented_input.items)
+	out_items[output:get_name()] = (out_items[output:get_name()] or 0) + output:get_count()
+	local empty_count = 0
+	for _,item in pairs(inventory:get_list("dst")) do
+		if item:is_empty() then
+			empty_count = empty_count + 1
+		else
+			local name = item:get_name()
+			if out_items[name] then
+				out_items[name] = out_items[name] - item:get_free_space()
+			end
+		end
+	end
+	for _,count in pairs(out_items) do
+		if count > 0 then
+			empty_count = empty_count - 1
+		end
+	end
+	if empty_count < 0 then
+		return false
 	end
 	-- consume material
 	for itemname, number in pairs(consumption) do
@@ -53,7 +75,7 @@ local function autocraft(inventory, craft)
 	end
 
 	-- craft the result into the dst inventory and add any "replacements" as well
-	inventory:add_item("dst", output_item)
+	inventory:add_item("dst", output)
 	for i = 1, 9 do
 		inventory:add_item("dst", craft.decremented_input.items[i])
 	end


### PR DESCRIPTION
Simpler version of #69, #70, #71

Works by counting all the output items and replacements, and then comparing that to the space in the `dst` inventory, including partial stacks.

Or to put it a different way, it subtracts the free space from the output items and checks if there is a remainder.

Fixes #61