### PR TITLE
Autocrafter groups support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+tab_width = 4
+charset = utf-8
+end_of_line = lf
+indent_style = tab
+insert_final_newline = false
+trim_trailing_whitespace = true

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -67,7 +67,6 @@ local function get_craft(pos, inventory, hash)
 	local craft = autocrafterCache[hash]
 	if craft then return craft end
 
-		craft = {recipe = recipe, consumption=count_index(recipe), output = output, decremented_input = decremented_input}
 	local example_recipe = inventory:get_list("recipe")
 	local output, decremented_input = minetest.get_craft_result({
 		method = "normal", width = 3, items = example_recipe
@@ -77,6 +76,13 @@ local function get_craft(pos, inventory, hash)
 	if output and not output.item:is_empty() then
 		recipe = get_matching_craft(output.item:get_name(), example_recipe)
 	end
+
+	craft = {
+		recipe = recipe,
+		consumption = count_index(recipe),
+		output = output,
+		decremented_input = decremented_input.items
+	}
 	autocrafterCache[hash] = craft
 	return craft
 end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -191,9 +191,6 @@ local function autocraft(inventory, craft)
 		return false
 	end
 
-	for itemname, number in pairs(consumption) do
-		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
-	end
 	-- consume material
 	for itemname, number in pairs(consumption) do
 		for _ = 1, number do -- We have to do that since remove_item does not work if count > stack_max

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -1,5 +1,7 @@
 local S = minetest.get_translator("pipeworks")
-local autocrafterCache = {}  -- caches some recipe data to avoid to call the slow function minetest.get_craft_result() every second
+-- cache some recipe data to avoid calling the slow function
+-- minetest.get_craft_result() every second
+local autocrafterCache = {}
 
 local craft_time = 1
 
@@ -116,6 +118,7 @@ local function calculate_consumption(inv_index, consumption_with_groups)
 	end
 
 	-- Next, resolve groups using the remaining items in the inventory
+	local take
 	if #groups > 0 then
 		for itemname, count in pairs(inv_index) do
 			if count > 0 then
@@ -124,11 +127,17 @@ local function calculate_consumption(inv_index, consumption_with_groups)
 				for i = 1, #groups do
 					local group = groups[i]
 					local groupname = "group:" .. group
-					if item_groups[group] and item_groups[group] >= 1 and consumption_with_groups[groupname] > 0 then
-						local take = math.min(count, consumption_with_groups[groupname])
-						consumption_with_groups[groupname] = consumption_with_groups[groupname] - take
+					if item_groups[group] and item_groups[group] >= 1
+						and consumption_with_groups[groupname] > 0
+					then
+						take = math.min(count, consumption_with_groups[groupname])
+						consumption_with_groups[groupname] =
+								consumption_with_groups[groupname] - take
+
 						assert(consumption_with_groups[groupname] >= 0)
-						consumption[itemname] = (consumption[itemname] or 0) + take
+						consumption[itemname] =
+								(consumption[itemname] or 0) + take
+
 						inv_index[itemname] = inv_index[itemname] - take
 						assert(inv_index[itemname] >= 0)
 					end
@@ -178,7 +187,9 @@ local function autocraft(inventory, craft)
 	-- check if output and all replacements fit in dst
 	local output = craft.output.item
 	local out_items = count_index(craft.decremented_input)
-	out_items[output:get_name()] = (out_items[output:get_name()] or 0) + output:get_count()
+	out_items[output:get_name()] =
+			(out_items[output:get_name()] or 0) + output:get_count()
+
 	if not has_room_for_output(inventory:get_list("dst"), out_items) then
 		return false
 	end
@@ -192,7 +203,8 @@ local function autocraft(inventory, craft)
 
 	-- consume material
 	for itemname, number in pairs(consumption) do
-		for _ = 1, number do -- We have to do that since remove_item does not work if count > stack_max
+		-- We have to do that since remove_item does not work if count > stack_max
+		for _ = 1, number do
 			inventory:remove_item("src", ItemStack(itemname))
 		end
 	end
@@ -203,14 +215,16 @@ local function autocraft(inventory, craft)
 	for i = 1, 9 do
 		leftover = inventory:add_item("dst", craft.decremented_input[i])
 		if leftover and not leftover:is_empty() then
-			minetest.log("warning", "[pipeworks] autocrafter didn't calculate output space correctly.")
+			minetest.log("warning", "[pipeworks] autocrafter didn't " ..
+				"calculate output space correctly.")
 		end
 	end
 	return true
 end
 
 -- returns false to stop the timer, true to continue running
--- is started only from start_autocrafter(pos) after sanity checks and cached recipe
+-- is started only from start_autocrafter(pos) after sanity checks and
+-- recipe is cached
 local function run_autocrafter(pos, elapsed)
 	local meta = minetest.get_meta(pos)
 	local inventory = meta:get_inventory()
@@ -265,7 +279,8 @@ local function after_recipe_change(pos, inventory)
 	after_inventory_change(pos)
 end
 
--- clean out unknown items and groups, which would be handled like unknown items in the crafting grid
+-- clean out unknown items and groups, which would be handled like unknown
+-- items in the crafting grid
 -- if minetest supports query by group one day, this might replace them
 -- with a canonical version instead
 local function normalize(item_list)
@@ -302,7 +317,8 @@ local function on_output_change(pos, inventory, stack)
 	after_recipe_change(pos, inventory)
 end
 
--- returns false if we shouldn't bother attempting to start the timer again after this
+-- returns false if we shouldn't bother attempting to start the timer again
+-- after this
 local function update_meta(meta, enabled)
 	local state = enabled and "on" or "off"
 	meta:set_int("enabled", enabled and 1 or 0)
@@ -311,17 +327,20 @@ local function update_meta(meta, enabled)
 		list_backgrounds = "style_type[box;colors=#666]"
 		for i = 0, 2 do
 			for j = 0, 2 do
-				list_backgrounds = list_backgrounds .. "box[" .. 0.22 + (i * 1.25) .. "," .. 0.22 + (j * 1.25) .. ";1,1;]"
+				list_backgrounds = list_backgrounds .. "box[" ..
+					0.22 + (i * 1.25) .. "," .. 0.22 + (j * 1.25) .. ";1,1;]"
 			end
 		end
 		for i = 0, 3 do
 			for j = 0, 2 do
-				list_backgrounds = list_backgrounds .. "box[" .. 5.28 + (i * 1.25) .. "," .. 0.22 + (j * 1.25) .. ";1,1;]"
+				list_backgrounds = list_backgrounds .. "box[" ..
+					5.28 + (i * 1.25) .. "," .. 0.22 + (j * 1.25) .. ";1,1;]"
 			end
 		end
 		for i = 0, 7 do
 			for j = 0, 2 do
-				list_backgrounds = list_backgrounds .. "box[" .. 0.22 + (i * 1.25) .. "," .. 5 + (j * 1.25) .. ";1,1;]"
+				list_backgrounds = list_backgrounds .. "box[" ..
+					0.22 + (i * 1.25) .. "," .. 5 + (j * 1.25) .. ";1,1;]"
 			end
 		end
 	end
@@ -334,7 +353,8 @@ local function update_meta(meta, enabled)
 		"list[context;recipe;0.22,0.22;3,3;]" ..
 		"image[4,1.45;1,1;[combine:16x16^[noalpha^[colorize:#141318:255]" ..
 		"list[context;output;4,1.45;1,1;]" ..
-		"image_button[4,2.6;1,0.6;pipeworks_button_" .. state .. ".png;" .. state .. ";;;false;pipeworks_button_interm.png]" ..
+		"image_button[4,2.6;1,0.6;pipeworks_button_" .. state .. ".png;" ..
+		state .. ";;;false;pipeworks_button_interm.png]" ..
 		"list[context;dst;5.28,0.22;4,3;]" ..
 		"list[context;src;0.22,5;8,3;]" ..
 		pipeworks.fs_helpers.get_inv(9) ..
@@ -344,7 +364,8 @@ local function update_meta(meta, enabled)
 		"listring[context;dst]" ..
 		"listring[current_player;main]"
 	if minetest.get_modpath("digilines") then
-		fs = fs .. "field[0.22,4.1;4.5,0.75;channel;" .. S("Channel") .. ";${channel}]" ..
+		fs = fs .. "field[0.22,4.1;4.5,0.75;channel;" .. S("Channel") ..
+			";${channel}]" ..
 			"button[5,4.1;1.5,0.75;set_channel;" .. S("Set") .. "]" ..
 			"button_exit[6.8,4.1;2,0.75;close;" .. S("Close") .. "]"
 	end
@@ -368,9 +389,12 @@ local function update_meta(meta, enabled)
 end
 
 -- 1st version of the autocrafter had actual items in the crafting grid
--- the 2nd replaced these with virtual items, dropped the content on update and set "virtual_items" to string "1"
--- the third added an output inventory, changed the formspec and added a button for enabling/disabling
--- so we work out way backwards on this history and update each single case to the newest version
+-- the 2nd replaced these with virtual items, dropped the content on update and
+--   set "virtual_items" to string "1"
+-- the third added an output inventory, changed the formspec and added a button
+--   for enabling/disabling
+-- so we work out way backwards on this history and update each single case
+--   to the newest version
 local function upgrade_autocrafter(pos, meta)
 	local meta = meta or minetest.get_meta(pos)
 	local inv = meta:get_inventory()
@@ -381,7 +405,8 @@ local function upgrade_autocrafter(pos, meta)
 		update_meta(meta, true)
 
 		if meta:get_string("virtual_items") == "1" then -- we are version 2
-			-- we already dropped stuff, so lets remove the metadatasetting (we are not being called again for this node)
+			-- we already dropped stuff, so lets remove the metadatasetting
+			-- (we are not being called again for this node)
 			meta:set_string("virtual_items", "")
 		else -- we are version 1
 			local recipe = inv:get_list("recipe")
@@ -406,9 +431,13 @@ minetest.register_node("pipeworks:autocrafter", {
 	description = S("Autocrafter"),
 	drawtype = "normal",
 	tiles = {"pipeworks_autocrafter.png"},
-	groups = {snappy = 3, tubedevice = 1, tubedevice_receiver = 1, dig_generic = 1, axey = 5},
+	groups = {
+		snappy = 3, tubedevice = 1, tubedevice_receiver = 1,
+		dig_generic = 1, axey = 5
+	},
 	_mcl_hardness = 1.6,
-	tube = {insert_object = function(pos, node, stack, direction)
+	tube = {
+		insert_object = function(pos, node, stack, direction)
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
 			local added = inv:add_item("src", stack)
@@ -421,7 +450,10 @@ minetest.register_node("pipeworks:autocrafter", {
 			return inv:room_for_item("src", stack)
 		end,
 		input_inventory = "dst",
-		connect_sides = {left = 1, right = 1, front = 1, back = 1, top = 1, bottom = 1}},
+		connect_sides = {
+			left = 1, right = 1, front = 1, back = 1, top = 1, bottom = 1
+			}
+	},
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
@@ -432,7 +464,9 @@ minetest.register_node("pipeworks:autocrafter", {
 		update_meta(meta, false)
 	end,
 	on_receive_fields = function(pos, formname, fields, sender)
-		if (fields.quit and not fields.key_enter_field) or not pipeworks.may_configure(pos, sender) then
+		if (fields.quit and not fields.key_enter_field)
+			or not pipeworks.may_configure(pos, sender)
+		then
 			return
 		end
 		local meta = minetest.get_meta(pos)
@@ -479,7 +513,9 @@ minetest.register_node("pipeworks:autocrafter", {
 	end,
 	allow_metadata_inventory_take = function(pos, listname, index, stack, player)
 		if not pipeworks.may_configure(pos, player) then
-			minetest.log("action", string.format("%s attempted to take from autocrafter at %s", player:get_player_name(), minetest.pos_to_string(pos)))
+			minetest.log("action", string.format("%s attempted to take from " ..
+				"autocrafter at %s",
+				player:get_player_name(), minetest.pos_to_string(pos)))
 			return 0
 		end
 		upgrade_autocrafter(pos)
@@ -495,7 +531,9 @@ minetest.register_node("pipeworks:autocrafter", {
 		after_inventory_change(pos)
 		return stack:get_count()
 	end,
-	allow_metadata_inventory_move = function(pos, from_list, from_index, to_list, to_index, count, player)
+	allow_metadata_inventory_move = function(
+			pos, from_list, from_index, to_list, to_index, count, player)
+
 		if not pipeworks.may_configure(pos, player) then return 0 end
 		upgrade_autocrafter(pos)
 		local inv = minetest.get_meta(pos):get_inventory()
@@ -540,7 +578,8 @@ minetest.register_node("pipeworks:autocrafter", {
 						for x = 1, 3, 1 do
 							local slot = y * 3 + x
 							if minetest.registered_items[msg[y + 1][x]] then
-								inv:set_stack("recipe", slot, ItemStack(msg[y + 1][x]))
+								inv:set_stack("recipe", slot, ItemStack(
+									msg[y + 1][x]))
 							else
 								inv:set_stack("recipe", slot, ItemStack(""))
 							end
@@ -555,7 +594,8 @@ minetest.register_node("pipeworks:autocrafter", {
 						local row = {}
 						for x = 1, 3, 1 do
 							local slot = y * 3 + x
-							table.insert(row, inv:get_stack("recipe", slot):get_name())
+							table.insert(row, inv:get_stack(
+									"recipe", slot):get_name())
 						end
 						table.insert(recipe, row)
 					end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -148,31 +148,19 @@ local function calculate_consumption(inv_index, consumption_with_groups)
 	return consumption
 end
 
-local function autocraft(inventory, craft)
-	if not craft then return false end
-
-	-- check if output and all replacements fit in dst
-	local output = craft.output.item
-	local out_items = count_index(craft.decremented_input.items)
-	out_items[output:get_name()] = (out_items[output:get_name()] or 0) + output:get_count()
 local function has_room_for_output(list_output, index_output)
 	local name
 	local empty_count = 0
-	for _,item in pairs(inventory:get_list("dst")) do
 	for _, item in pairs(list_output) do
 		if item:is_empty() then
 			empty_count = empty_count + 1
 		else
-			local name = item:get_name()
-			if out_items[name] then
-				out_items[name] = out_items[name] - item:get_free_space()
 			name = item:get_name()
 			if index_output[name] then
 				index_output[name] = index_output[name] - item:get_free_space()
 			end
 		end
 	end
-	for _,count in pairs(out_items) do
 	for _, count in pairs(index_output) do
 		if count > 0 then
 			empty_count = empty_count - 1
@@ -184,6 +172,17 @@ local function has_room_for_output(list_output, index_output)
 
 	return true
 end
+
+local function autocraft(inventory, craft)
+	if not craft then return false end
+
+	-- check if output and all replacements fit in dst
+	local output = craft.output.item
+	local out_items = count_index(craft.decremented_input)
+	out_items[output:get_name()] = (out_items[output:get_name()] or 0) + output:get_count()
+	if not has_room_for_output(inventory:get_list("dst"), out_items) then
+		return false
+	end
 
 	-- check if we have enough material available
 	local inv_index = count_index(inventory:get_list("src"))

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -101,16 +101,6 @@ end
 
 local function autocraft(inventory, craft)
 	if not craft then return false end
-	-- check if we have enough material available
-	local inv_index = count_index(inventory:get_list("src"))
-	local consumption = calculate_consumption(inv_index, craft.consumption)
-	if not consumption then
-		return false
-	end
-	-- check if we have enough material available
-	for itemname, number in pairs(consumption) do
-		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
-	end
 	-- check if output and all replacements fit in dst
 	local output = craft.output.item
 	local out_items = count_index(craft.decremented_input.items)
@@ -134,8 +124,17 @@ local function autocraft(inventory, craft)
 	if empty_count < 0 then
 		return false
 	end
+	-- check if we have enough material available
+	local inv_index = count_index(inventory:get_list("src"))
+	local consumption = calculate_consumption(inv_index, craft.consumption)
+	if not consumption then
+		return false
+	end
+	for itemname, number in pairs(consumption) do
+		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
+	end
 	-- consume material
-	for itemname, number in pairs(craft.consumption) do
+	for itemname, number in pairs(consumption) do
 		for _ = 1, number do -- We have to do that since remove_item does not work if count > stack_max
 			inventory:remove_item("src", ItemStack(itemname))
 		end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -125,7 +125,7 @@ local function calculate_consumption(inv_index, consumption_with_groups)
 				for i = 1, #groups do
 					local group = groups[i]
 					local groupname = "group:" .. group
-					if item_groups[group] >= 1 and consumption_with_groups[groupname] > 0 then
+					if item_groups[group] and item_groups[group] >= 1 and consumption_with_groups[groupname] > 0 then
 						local take = math.min(count, consumption_with_groups[groupname])
 						consumption_with_groups[groupname] = consumption_with_groups[groupname] - take
 						assert(consumption_with_groups[groupname] >= 0)

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -49,7 +49,8 @@ local function calculate_consumption(inv_index, consumption_with_groups)
 	local groups = {}
 
 	-- First consume all non-group requirements
-	-- This is done to avoid consuming a non-group item which is also in a group
+	-- This is done to avoid consuming a non-group item which is also
+	-- in a group
 	for key, count in pairs(consumption_with_groups) do
 		if key:sub(1, 6) == "group:" then
 			groups[#groups + 1] = key:sub(7, #key)
@@ -73,7 +74,7 @@ local function calculate_consumption(inv_index, consumption_with_groups)
 			if count > 0 then
 				local def = minetest.registered_items[itemname]
 				local item_groups = def and def.groups or {}
-				for i=1, #groups do
+				for i = 1, #groups do
 					local group = groups[i]
 					local groupname = "group:" .. group
 					if item_groups[group] >= 1 and consumption_with_groups[groupname] > 0 then
@@ -101,6 +102,7 @@ end
 
 local function autocraft(inventory, craft)
 	if not craft then return false end
+
 	-- check if output and all replacements fit in dst
 	local output = craft.output.item
 	local out_items = count_index(craft.decremented_input.items)
@@ -124,12 +126,14 @@ local function autocraft(inventory, craft)
 	if empty_count < 0 then
 		return false
 	end
+
 	-- check if we have enough material available
 	local inv_index = count_index(inventory:get_list("src"))
 	local consumption = calculate_consumption(inv_index, craft.consumption)
 	if not consumption then
 		return false
 	end
+
 	for itemname, number in pairs(consumption) do
 		if (not inv_index[itemname]) or inv_index[itemname] < number then return false end
 	end
@@ -161,7 +165,7 @@ local function run_autocrafter(pos, elapsed)
 		return false
 	end
 
-	for _ = 1, math.floor(elapsed/craft_time) do
+	for _ = 1, math.floor(elapsed / craft_time) do
 		local continue = autocraft(inventory, craft)
 		if not continue then return false end
 	end
@@ -251,7 +255,8 @@ local function on_output_change(pos, inventory, stack)
 			end
 			width_idx = (width_idx < 3) and (width_idx + 1) or 1
 		end
-		-- we'll set the output slot in after_recipe_change to the actual result of the new recipe
+		-- we'll set the output slot in after_recipe_change to the actual
+		-- result of the new recipe
 	end
 	after_recipe_change(pos, inventory)
 end
@@ -263,46 +268,46 @@ local function update_meta(meta, enabled)
 	local list_backgrounds = ""
 	if minetest.get_modpath("i3") then
 		list_backgrounds = "style_type[box;colors=#666]"
-		for i=0, 2 do
-			for j=0, 2 do
-				list_backgrounds = list_backgrounds .. "box[".. 0.22+(i*1.25) ..",".. 0.22+(j*1.25) ..";1,1;]"
+		for i = 0, 2 do
+			for j = 0, 2 do
+				list_backgrounds = list_backgrounds .. "box[" .. 0.22 + (i * 1.25) .. "," .. 0.22 + (j * 1.25) .. ";1,1;]"
 			end
 		end
-		for i=0, 3 do
-			for j=0, 2 do
-				list_backgrounds = list_backgrounds .. "box[".. 5.28+(i*1.25) ..",".. 0.22+(j*1.25) ..";1,1;]"
+		for i = 0, 3 do
+			for j = 0, 2 do
+				list_backgrounds = list_backgrounds .. "box[" .. 5.28 + (i * 1.25) .. "," .. 0.22 + (j * 1.25) .. ";1,1;]"
 			end
 		end
-		for i=0, 7 do
-			for j=0, 2 do
-				list_backgrounds = list_backgrounds .. "box[".. 0.22+(i*1.25) ..",".. 5+(j*1.25) ..";1,1;]"
+		for i = 0, 7 do
+			for j = 0, 2 do
+				list_backgrounds = list_backgrounds .. "box[" .. 0.22 + (i * 1.25) .. "," .. 5 + (j * 1.25) .. ";1,1;]"
 			end
 		end
 	end
 	local size = "10.2,14"
 	local fs =
-		"formspec_version[2]"..
-		"size["..size.."]"..
-		pipeworks.fs_helpers.get_prepends(size)..
-		list_backgrounds..
-		"list[context;recipe;0.22,0.22;3,3;]"..
-		"image[4,1.45;1,1;[combine:16x16^[noalpha^[colorize:#141318:255]"..
-		"list[context;output;4,1.45;1,1;]"..
+		"formspec_version[2]" ..
+		"size[" .. size .. "]" ..
+		pipeworks.fs_helpers.get_prepends(size) ..
+		list_backgrounds ..
+		"list[context;recipe;0.22,0.22;3,3;]" ..
+		"image[4,1.45;1,1;[combine:16x16^[noalpha^[colorize:#141318:255]" ..
+		"list[context;output;4,1.45;1,1;]" ..
 		"image_button[4,2.6;1,0.6;pipeworks_button_" .. state .. ".png;" .. state .. ";;;false;pipeworks_button_interm.png]" ..
-		"list[context;dst;5.28,0.22;4,3;]"..
-		"list[context;src;0.22,5;8,3;]"..
-		pipeworks.fs_helpers.get_inv(9)..
-		"listring[current_player;main]"..
+		"list[context;dst;5.28,0.22;4,3;]" ..
+		"list[context;src;0.22,5;8,3;]" ..
+		pipeworks.fs_helpers.get_inv(9) ..
+		"listring[current_player;main]" ..
 		"listring[context;src]" ..
-		"listring[current_player;main]"..
+		"listring[current_player;main]" ..
 		"listring[context;dst]" ..
 		"listring[current_player;main]"
 	if minetest.get_modpath("digilines") then
-		fs = fs.."field[0.22,4.1;4.5,0.75;channel;"..S("Channel")..";${channel}]"..
-			"button[5,4.1;1.5,0.75;set_channel;"..S("Set").."]"..
-			"button_exit[6.8,4.1;2,0.75;close;"..S("Close").."]"
+		fs = fs .. "field[0.22,4.1;4.5,0.75;channel;" .. S("Channel") .. ";${channel}]" ..
+			"button[5,4.1;1.5,0.75;set_channel;" .. S("Set") .. "]" ..
+			"button_exit[6.8,4.1;2,0.75;close;" .. S("Close") .. "]"
 	end
-	meta:set_string("formspec",fs)
+	meta:set_string("formspec", fs)
 
 	-- toggling the button doesn't quite call for running a recipe change check
 	-- so instead we run a minimal version for infotext setting only
@@ -360,8 +365,8 @@ minetest.register_node("pipeworks:autocrafter", {
 	description = S("Autocrafter"),
 	drawtype = "normal",
 	tiles = {"pipeworks_autocrafter.png"},
-	groups = {snappy = 3, tubedevice = 1, tubedevice_receiver = 1, dig_generic = 1, axey=5},
-	_mcl_hardness=1.6,
+	groups = {snappy = 3, tubedevice = 1, tubedevice_receiver = 1, dig_generic = 1, axey = 5},
+	_mcl_hardness = 1.6,
 	tube = {insert_object = function(pos, node, stack, direction)
 			local meta = minetest.get_meta(pos)
 			local inv = meta:get_inventory()
@@ -379,9 +384,9 @@ minetest.register_node("pipeworks:autocrafter", {
 	on_construct = function(pos)
 		local meta = minetest.get_meta(pos)
 		local inv = meta:get_inventory()
-		inv:set_size("src", 3*8)
-		inv:set_size("recipe", 3*3)
-		inv:set_size("dst", 4*3)
+		inv:set_size("src", 3 * 8)
+		inv:set_size("recipe", 3 * 3)
+		inv:set_size("dst", 4 * 3)
 		inv:set_size("output", 1)
 		update_meta(meta, false)
 	end,
@@ -490,13 +495,13 @@ minetest.register_node("pipeworks:autocrafter", {
 				if type(msg) == "table" then
 					if #msg < 3 then return end
 					local inv = meta:get_inventory()
-					for y=0,2,1 do
-						for x=1,3,1 do
-							local slot = y*3+x
-							if minetest.registered_items[msg[y+1][x]] then
-								inv:set_stack("recipe",slot,ItemStack(msg[y+1][x]))
+					for y = 0, 2, 1 do
+						for x = 1, 3, 1 do
+							local slot = y * 3 + x
+							if minetest.registered_items[msg[y + 1][x]] then
+								inv:set_stack("recipe", slot, ItemStack(msg[y + 1][x]))
 							else
-								inv:set_stack("recipe",slot,ItemStack(""))
+								inv:set_stack("recipe", slot, ItemStack(""))
 							end
 						end
 					end
@@ -505,11 +510,11 @@ minetest.register_node("pipeworks:autocrafter", {
 					local meta = minetest.get_meta(pos)
 					local inv = meta:get_inventory()
 					local recipe = {}
-					for y=0,2,1 do
+					for y = 0, 2, 1 do
 						local row = {}
-						for x=1,3,1 do
-							local slot = y*3+x
-							table.insert(row, inv:get_stack("recipe",slot):get_name())
+						for x = 1, 3, 1 do
+							local slot = y * 3 + x
+							table.insert(row, inv:get_stack("recipe", slot):get_name())
 						end
 						table.insert(recipe, row)
 					end
@@ -536,4 +541,4 @@ minetest.register_node("pipeworks:autocrafter", {
 		},
 	},
 })
-pipeworks.ui_cat_tube_list[#pipeworks.ui_cat_tube_list+1] = "pipeworks:autocrafter"
+pipeworks.ui_cat_tube_list[#pipeworks.ui_cat_tube_list + 1] = "pipeworks:autocrafter"

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -36,7 +36,7 @@ local function get_matching_craft(output_name, example_recipe)
 
 	local index_example = count_index(example_recipe)
 	local best_score = 0
-	local index_recipe, best_index, score, group, def
+	local index_recipe, best_index, score, group
 	for i = 1, #recipes do
 		score = 0
 		index_recipe = count_index(recipes[i].items)
@@ -46,8 +46,7 @@ local function get_matching_craft(output_name, example_recipe)
 			elseif recipe_item_name:sub(1, 6) == "group:" then
 				group = recipe_item_name:sub(7)
 				for example_item_name, _ in pairs(index_example) do
-					def = minetest.registered_items[example_item_name]
-					if def and def.groups[group] and def.groups[group] > 0 then
+					if minetest.get_item_group(example_item_name, group) > 0 then
 						score = score + 1
 						break
 					end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -189,18 +189,17 @@ end
 -- note, that this function assumes allready being updated to virtual items
 -- and doesn't handle recipes with stacksizes > 1
 local function after_recipe_change(pos, inventory)
+	local hash = minetest.hash_node_position(pos)
 	local meta = minetest.get_meta(pos)
 	-- if we emptied the grid, there's no point in keeping it running or cached
 	if inventory:is_empty("recipe") then
 		minetest.get_node_timer(pos):stop()
-		autocrafterCache[minetest.hash_node_position(pos)] = nil
+		autocrafterCache[hash] = nil
 		meta:set_string("infotext", S("unconfigured Autocrafter"))
 		inventory:set_stack("output", 1, "")
 		return
 	end
 	local recipe = inventory:get_list("recipe")
-
-	local hash = minetest.hash_node_position(pos)
 	local craft = autocrafterCache[hash]
 
 	if craft then

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -65,17 +65,19 @@ end
 local function get_craft(pos, inventory, hash)
 	local hash = hash or minetest.hash_node_position(pos)
 	local craft = autocrafterCache[hash]
-		local example_recipe = inventory:get_list("recipe")
-		local output, decremented_input = minetest.get_craft_result({method = "normal", width = 3, items = example_recipe})
-		local recipe = example_recipe
-		if output and not output.item:is_empty() then
 			recipe = minetest.get_craft_recipe(output.item:get_name()).items or example_recipe
-		end
 	if craft then return craft end
 
 		craft = {recipe = recipe, consumption=count_index(recipe), output = output, decremented_input = decremented_input}
-		autocrafterCache[hash] = craft
+	local example_recipe = inventory:get_list("recipe")
+	local output, decremented_input = minetest.get_craft_result({
+		method = "normal", width = 3, items = example_recipe
+	})
+
+	local recipe = example_recipe
+	if output and not output.item:is_empty() then
 	end
+	autocrafterCache[hash] = craft
 	return craft
 end
 

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -65,13 +65,13 @@ end
 local function get_craft(pos, inventory, hash)
 	local hash = hash or minetest.hash_node_position(pos)
 	local craft = autocrafterCache[hash]
-	if not craft then
 		local example_recipe = inventory:get_list("recipe")
 		local output, decremented_input = minetest.get_craft_result({method = "normal", width = 3, items = example_recipe})
 		local recipe = example_recipe
 		if output and not output.item:is_empty() then
 			recipe = minetest.get_craft_recipe(output.item:get_name()).items or example_recipe
 		end
+	if craft then return craft end
 
 		craft = {recipe = recipe, consumption=count_index(recipe), output = output, decremented_input = decremented_input}
 		autocrafterCache[hash] = craft

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -249,30 +249,16 @@ end
 local function after_recipe_change(pos, inventory)
 	local hash = minetest.hash_node_position(pos)
 	local meta = minetest.get_meta(pos)
+	autocrafterCache[hash] = nil
 	-- if we emptied the grid, there's no point in keeping it running or cached
 	if inventory:is_empty("recipe") then
 		minetest.get_node_timer(pos):stop()
-		autocrafterCache[hash] = nil
 		meta:set_string("infotext", S("unconfigured Autocrafter"))
 		inventory:set_stack("output", 1, "")
 		return
 	end
 	local recipe = inventory:get_list("recipe")
-	local craft = autocrafterCache[hash]
-
-	if craft then
-		-- check if it changed
-		local cached_recipe = craft.recipe
-		for i = 1, 9 do
-			if recipe[i]:get_name() ~= cached_recipe[i]:get_name() then
-				autocrafterCache[hash] = nil -- invalidate recipe
-				craft = nil
-				break
-			end
-		end
-	end
-
-	craft = craft or get_craft(pos, inventory, hash)
+	local craft = get_craft(pos, inventory, hash)
 	local output_item = craft.output.item
 	local description, name = get_item_info(output_item)
 	meta:set_string("infotext", S("'@1' Autocrafter (@2)", description, name))

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -65,7 +65,6 @@ end
 local function get_craft(pos, inventory, hash)
 	local hash = hash or minetest.hash_node_position(pos)
 	local craft = autocrafterCache[hash]
-			recipe = minetest.get_craft_recipe(output.item:get_name()).items or example_recipe
 	if craft then return craft end
 
 		craft = {recipe = recipe, consumption=count_index(recipe), output = output, decremented_input = decremented_input}
@@ -76,6 +75,7 @@ local function get_craft(pos, inventory, hash)
 
 	local recipe = example_recipe
 	if output and not output.item:is_empty() then
+		recipe = get_matching_craft(output.item:get_name(), example_recipe)
 	end
 	autocrafterCache[hash] = craft
 	return craft

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -200,8 +200,12 @@ local function autocraft(inventory, craft)
 
 	-- craft the result into the dst inventory and add any "replacements" as well
 	inventory:add_item("dst", output)
+	local leftover
 	for i = 1, 9 do
-		inventory:add_item("dst", craft.decremented_input.items[i])
+		leftover = inventory:add_item("dst", craft.decremented_input[i])
+		if leftover and not leftover:is_empty() then
+			minetest.log("warning", "[pipeworks] autocrafter didn't calculate output space correctly.")
+		end
 	end
 	return true
 end

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -257,7 +257,6 @@ local function after_recipe_change(pos, inventory)
 		inventory:set_stack("output", 1, "")
 		return
 	end
-	local recipe = inventory:get_list("recipe")
 	local craft = get_craft(pos, inventory, hash)
 	local output_item = craft.output.item
 	local description, name = get_item_info(output_item)

--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -155,18 +155,25 @@ local function autocraft(inventory, craft)
 	local output = craft.output.item
 	local out_items = count_index(craft.decremented_input.items)
 	out_items[output:get_name()] = (out_items[output:get_name()] or 0) + output:get_count()
+local function has_room_for_output(list_output, index_output)
+	local name
 	local empty_count = 0
 	for _,item in pairs(inventory:get_list("dst")) do
+	for _, item in pairs(list_output) do
 		if item:is_empty() then
 			empty_count = empty_count + 1
 		else
 			local name = item:get_name()
 			if out_items[name] then
 				out_items[name] = out_items[name] - item:get_free_space()
+			name = item:get_name()
+			if index_output[name] then
+				index_output[name] = index_output[name] - item:get_free_space()
 			end
 		end
 	end
 	for _,count in pairs(out_items) do
+	for _, count in pairs(index_output) do
 		if count > 0 then
 			empty_count = empty_count - 1
 		end
@@ -174,6 +181,9 @@ local function autocraft(inventory, craft)
 	if empty_count < 0 then
 		return false
 	end
+
+	return true
+end
 
 	-- check if we have enough material available
 	local inv_index = count_index(inventory:get_list("src"))

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,60 @@ Changelog
 
 
 
+2023-06-22 (SwissalpS, rubenwardy)
+groups support in recipe. Set recipe as usual via recipe formspec or digilines.
+Autocrafter now resolves matching recipe using groups so that items in input
+inventory are used, that match group and no longer only strictly what user
+has in recipe-inventory
+
+
+
+2023-06-21 (OgelGames, BuckarooBanzay)
+fix autocrafter destroying replacement items (OG)
+remove facedir debugging logs (BB)
+
+
+
+2023-05-28 (SwissalpS)
+support setting 'can_receive' for teleport tubes via digiline
+
+
+
+2023-05-19 (fluxionary, OgelGames)
+log items going through teleport tubes
+
+
+
+2022-12-02 (wsor4035)
+bring back compatibility with mineclone2
+
+
+
+2022-11-11 (OgelGames)
+prevent tp- and sand-tubes from breaking themselves and refactor part of code
+
+2022-09-18 (fluxionary)
+protection checks before break-/placeing a node -> less violation logs
+
+
+2022-08-14 (wsor4035)
+prevent tubes from connecting to furnace front
+
+
+
+2022-08-13 (TurkeyMcMac)
+moved teleport-tube database to mod-storage
+
+
+
+2022-06-23 (S-S-X)
+on_repair tweak, improved repairing tubes
+
+
+* many updates not mentioned here *
+
+
+
 2017-10-19 (thetaepsilon)
 Directional flowables are now implemented.
 All devices for which it is relevant (valve, flow sensor etc.) have been converted so that they only flow on their connecting sides, so pressure propogation now works as expected for these devices when pressure logic is enabled.

--- a/changelog.txt
+++ b/changelog.txt
@@ -104,91 +104,91 @@ What *does not* work:
 
 *seems this hasn't been updated in a while*
 
-2013-01-13: Tubes can transport items now! Namely, I added Novatux/Nore's item 
+2013-01-13: Tubes can transport items now! Namely, I added Novatux/Nore's item
 transport mod as a default part of this mod, to make tubes do something useful!
 Thanks to Nore and RealBadAngel for the code contributions!
 
-2013-01-05: made storage tanks connect from top/bottom, made storage tank and 
-pipe textures use the ^ combine operator so they can show the actual liquid 
+2013-01-05: made storage tanks connect from top/bottom, made storage tank and
+pipe textures use the ^ combine operator so they can show the actual liquid
 going through the pipes/tanks.
 
-2013-01-04 (a bit later): Made pipes able to carry water! It was just a minor 
-logic error resulting from moving the water flowing code into it's own file 
+2013-01-04 (a bit later): Made pipes able to carry water! It was just a minor
+logic error resulting from moving the water flowing code into it's own file
 when I originally imported it.  Many thanks to Mauvebic for writing it!
 
-2013-01-04: First stage of integrating Mauvebic's water flowing code.  This is 
-experimental and doesn't move water yet - but at least it doesn't break 
+2013-01-04: First stage of integrating Mauvebic's water flowing code.  This is
+experimental and doesn't move water yet - but at least it doesn't break
 anything :-)
 
-2013-01-01: Various minor tweaks to textures, facedir settings, some other 
-stuff.  Changed crafting recipes to account for revamped pumps, valves, etc.  
-Now requires the moreores mod and most recent git (for mese crystal fragments) 
-to craft a pump.  Added a "sealed" entry/exit panel (really just a horizontal 
-pipe with a metal panel overlayed into the middle).  Also, tweaked pipes to 
-always drop the empty ones.  Revamped pumps so that now they should sit in/on 
-liquid and be connected only from the top, relegated grates to decorational- 
-only, added outlet spigot.  Got rid of a few obsolete textures.  Got rid of 
-that whole _x and _z naming thing - now all directional devices (pumps, valves, 
-spigots, tanks) use facedir.  Valves, spigots no longer auto-rotate to find 
+2013-01-01: Various minor tweaks to textures, facedir settings, some other
+stuff.  Changed crafting recipes to account for revamped pumps, valves, etc.
+Now requires the moreores mod and most recent git (for mese crystal fragments)
+to craft a pump.  Added a "sealed" entry/exit panel (really just a horizontal
+pipe with a metal panel overlayed into the middle).  Also, tweaked pipes to
+always drop the empty ones.  Revamped pumps so that now they should sit in/on
+liquid and be connected only from the top, relegated grates to decorational-
+only, added outlet spigot.  Got rid of a few obsolete textures.  Got rid of
+that whole _x and _z naming thing - now all directional devices (pumps, valves,
+spigots, tanks) use facedir.  Valves, spigots no longer auto-rotate to find
 nearby pipes.
 
-2012-09-17: Added test object for pneumatic tube autorouting code, made tubes 
-connect to it and any object that bears groups={tubedevice=1} (connects to any 
+2012-09-17: Added test object for pneumatic tube autorouting code, made tubes
+connect to it and any object that bears groups={tubedevice=1} (connects to any
 side)
 
-2012-09-05: All recipes doubled except for junglegrass -> plastic sheet (since 
+2012-09-05: All recipes doubled except for junglegrass -> plastic sheet (since
 that is derived from home decor)
 
-2012-09-02: Fixed plastic sheeting recipe.  Added crafting recipes for various 
-objects, with options: If homedecor is installed, use the plastic sheeting 
-therein.  If not, we define it manually.  If the Technic mod is installed, 
-don't define any recipes at all.  Also removed the extra "loaded!" messages and 
-tweaked the default pipe alias to point to something that is actually visible 
+2012-09-02: Fixed plastic sheeting recipe.  Added crafting recipes for various
+objects, with options: If homedecor is installed, use the plastic sheeting
+therein.  If not, we define it manually.  If the Technic mod is installed,
+don't define any recipes at all.  Also removed the extra "loaded!" messages and
+tweaked the default pipe alias to point to something that is actually visible
 :-)
 
 2012-09-01:  flattened wielded pipe segment.
 
-2012-08-24: Added square-ish pneumatic tubes with their own autoplace code 
-(does not connect to steel pipes or pipe-oriented devices), then revised their 
-textures shortly after.  Fixed a recursion bug that sometimes caused a stack 
-overflow.  Old pipes were overriding the pipeworks:pipe defintion that belongs 
+2012-08-24: Added square-ish pneumatic tubes with their own autoplace code
+(does not connect to steel pipes or pipe-oriented devices), then revised their
+textures shortly after.  Fixed a recursion bug that sometimes caused a stack
+overflow.  Old pipes were overriding the pipeworks:pipe defintion that belongs
 with the new pipes.
 
-2012-08-22: Added outlet grate, made it participate in autoplace algorithm.  
-Extended storage tank to show fill level in 10% steps (0% to 100%).  Added 
-"expansion tank" that appears if the user stacks tanks upwards.  (Downwards is 
+2012-08-22: Added outlet grate, made it participate in autoplace algorithm.
+Extended storage tank to show fill level in 10% steps (0% to 100%).  Added
+"expansion tank" that appears if the user stacks tanks upwards.  (Downwards is
 not checked).
 
-2012-08-21: Made storage tank participate in autoplace algorithm.  Tuned API a 
-little to allow for more flexible placement.  Re-organized code a bit to allow 
-for some upcoming rules changes.  Made storage tanks' upper/lower fittins and 
+2012-08-21: Made storage tank participate in autoplace algorithm.  Tuned API a
+little to allow for more flexible placement.  Re-organized code a bit to allow
+for some upcoming rules changes.  Made storage tanks' upper/lower fittins and
 intake grate participate in autoplace algorithm.
 
-2012-08-20: Added temporary nodes for storage tank and intake grating, but 
+2012-08-20: Added temporary nodes for storage tank and intake grating, but
 without autoplace.
 
-2012-08-19: Pumps and valves now fully participate in the 
+2012-08-19: Pumps and valves now fully participate in the
 auto-rotate/auto-place algorithm.
 
-2012-08-18: Total rewrite again.  All pipes are now nice and round-looking, and 
-they auto-connect!  Also added temporary nodes for pump and valve (each with an 
-on/off setting - punch to change).  No crafting recipes yet and the pipes still 
+2012-08-18: Total rewrite again.  All pipes are now nice and round-looking, and
+they auto-connect!  Also added temporary nodes for pump and valve (each with an
+on/off setting - punch to change).  No crafting recipes yet and the pipes still
 don't do anything useful yet.  Soon.
 
 2012-08-06:  Moved this changelog off the forum post and into a separate file.
 
-2012-08-05 (multiple updates): Rewrote pipeworks to use loops and tables to 
-create the nodes. Requires far less code now. Added -X, +X, -Y, +Y, -Z, +Z 
-capped stubs and a short centered horizontal segment. Changed node definitions 
-so that the aforementioned "short centered" segment is given on dig/drop.  
-Renamed it to just "pipeworks:pipe" (and pipe_loaded). Added empty/loaded 
-indicator images to the capped ends, removed some redundant comments. Made the 
+2012-08-05 (multiple updates): Rewrote pipeworks to use loops and tables to
+create the nodes. Requires far less code now. Added -X, +X, -Y, +Y, -Z, +Z
+capped stubs and a short centered horizontal segment. Changed node definitions
+so that the aforementioned "short centered" segment is given on dig/drop.
+Renamed it to just "pipeworks:pipe" (and pipe_loaded). Added empty/loaded
+indicator images to the capped ends, removed some redundant comments. Made the
 empty/loaded indication at the capped end more prominent.
 
-2012-07-21: Added screenshot showing pipes as they look now that nodebox 
+2012-07-21: Added screenshot showing pipes as they look now that nodebox
 texture rotation is fixed.
 
-2012-07-18: Changed the mod name and all internals to 'pipeworks' instead of 
+2012-07-18: Changed the mod name and all internals to 'pipeworks' instead of
 'pipes'... after a couple of mistakes :-)
 
 2012-07-12: moved project to github.


### PR DESCRIPTION
Based on work started by @rubenwardy https://gitlab.com/rubenwardy/pipeworks/-/commit/60673db48058539915e2fa2ffa4fd3ef21f421fb

- adds group support to autocrafter

Set recipe as usual in formspec or via digilines. Now autocrafter will use up any items that conform to actual recipe that was registered with groups.

e.g. set recipe to:
- any trunk, any leaves, any leaves
- any leaves, any leaves, any leaves
- any leaves, any leaves, any leaves
-> result output is set to bonemeal:mulch

- now fill input inventory with various trunks not used in recipe and leaves not used when setting recipe
- start autocrafter and watch it use up the available items

closes: #3

Edit: also snuck in some whitespace edits 9be6239