### PR TITLE
Fix item duplication bug with broken tubes.

### DIFF
--- a/routing_tubes.lua
+++ b/routing_tubes.lua
@@ -97,7 +97,16 @@ pipeworks.register_tube("pipeworks:broken_tube", {
 				pipeworks.logger(log_msg.." but original node "..was_node.name.." is not registered anymore.")
 				minetest.chat_send_player(playername, S("This tube cannot be repaired."))
 			end
-		end
+		end,
+		allow_metadata_inventory_put = function()
+			return 0
+		end,
+		allow_metadata_inventory_move = function()
+			return 0
+		end,
+		allow_metadata_inventory_take = function()
+			return 0
+		end,
 	}
 })
 


### PR DESCRIPTION
It was possible to drag items from broken sorting-/mese-tubes.