### PR TITLE
Pipe Hole Texture Toggle setting

### DIFF
--- a/compat-chests.lua
+++ b/compat-chests.lua
@@ -6,7 +6,7 @@
 
 -- Pipeworks Specific
 local fs_helpers = pipeworks.fs_helpers
-local tube_entry = "^pipeworks_tube_connection_wooden.png"
+local tube_entry = pipeworks.pipeworks_pipe_holes_wooden_texture
 
 -- Chest Locals
 local open_chests = {}
@@ -300,4 +300,3 @@ elseif minetest.get_modpath("hades_chests") then
 	minetest.override_item("hades_chests:chest_locked", override_protected)
   --minetest.override_item("hades_chests:chest_locked_open", override_protected_open)
 end
-

--- a/compat-furnaces.lua
+++ b/compat-furnaces.lua
@@ -10,7 +10,7 @@ elseif minetest.get_modpath("hades_furnaces") then
 	--def_active = table.copy(minetest.registered_nodes["hades_furnaces:furnace_active"])
 end
 
-local tube_entry = "^pipeworks_tube_connection_stony.png"
+local tube_entry = pipeworks.pipeworks_pipe_holes_stony_texture
 
 local groups = def.groups
 groups["tubedevice"] = 1
@@ -125,4 +125,3 @@ elseif minetest.get_modpath("hades_furnaces") then
 	minetest.override_item("hades_furnaces:furnace", override)
 	minetest.override_item("hades_furnaces:furnace_active", override_active)
 end
-

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -29,6 +29,7 @@ local settings = {
 	delete_item_on_clearobject = true,
 	use_real_entities = true,
 	entity_update_interval = 0,
+	show_pipe_holes = true,
 }
 
 pipeworks.toggles = {}

--- a/init.lua
+++ b/init.lua
@@ -21,6 +21,10 @@ pipeworks = {
 }
 
 dofile(pipeworks.modpath.."/default_settings.lua")
+
+pipeworks.pipeworks_pipe_holes_wooden_texture = pipeworks.show_pipe_holes  and "^pipeworks_tube_connection_wooden.png" or ""
+pipeworks.pipeworks_pipe_holes_stony_texture = pipeworks.show_pipe_holes and "^pipeworks_tube_connection_stony.png" or ""
+
 -- Read the external config file if it exists.
 local worldsettingspath = pipeworks.worldpath.."/pipeworks_settings.txt"
 local worldsettingsfile = io.open(worldsettingspath, "r")

--- a/mcl_barrels.lua
+++ b/mcl_barrels.lua
@@ -2,7 +2,7 @@
 -- pipeworks.
 
 -- Pipeworks Specific
-local tube_entry = "^pipeworks_tube_connection_wooden.png"
+local tube_entry = pipeworks.pipeworks_pipe_holes_wooden_texture
 
 -- Original Definitions
 local old_barrel = table.copy(minetest.registered_items["mcl_barrels:barrel_closed"])

--- a/mcl_furnaces.lua
+++ b/mcl_furnaces.lua
@@ -3,7 +3,7 @@ local old_furnace = table.copy(minetest.registered_nodes["mcl_furnaces:furnace"]
 local old_blast_furnace = table.copy(minetest.registered_nodes["mcl_blast_furnace:blast_furnace"])
 local old_smoker = table.copy(minetest.registered_nodes["mcl_smoker:smoker"])
 
-local tube_entry = "^pipeworks_tube_connection_stony.png"
+local tube_entry = pipeworks.pipeworks_pipe_holes_stony_texture
 
 -- groups
 local furnace_groups = old_furnace.groups

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -76,6 +76,9 @@ pipeworks_drop_on_routing_fail (Drop On Routing Fail) bool false
 #Delete item on clearobject.
 pipeworks_delete_item_on_clearobject (Delete Item On Clearobject) bool true
 
+# Enable Pipe Holes in supported node textures
+pipeworks_show_pipe_holes (Enable Pipe Hole Textures) bool true
+
 #Use real visible entities in tubes within active areas.
 #When disabled, tubes are made opaque.
 pipeworks_use_real_entities (Use Real Entities) bool true


### PR DESCRIPTION
Ive noticed some people don't like the texture of the pipe holes/ tube entry, added to the supported nodes.
This setting allows you to disable that texture if you want to.

This way everyone is happy, its only if the server owner wants the texture or not.
By default the texture is enabled (of course).

Let me know what you think.