### PR TITLE
export `pipeworks.tptube.remove_tube`

### DIFF
--- a/tubes/teleport.lua
+++ b/tubes/teleport.lua
@@ -357,6 +357,7 @@ pipeworks.tptube = {
 	hash = hash_pos,
 	get_db = function() return tube_db end,
 	save_tube_db = save_tube_db,
+	remove_tube = remove_tube,
 	set_tube = set_tube,
 	save_tube = save_tube,
 	update_tube = update_tube,


### PR DESCRIPTION
this PR adds the `remove_tube` function to the `pipeworks.tptube` global, to be used with mods that move the teleport-tubes, like the jumprive-mod currently.

TBD: documentation, see #104 (in another PR)