### PR TITLE
Get rid of random print() calls

### DIFF
--- a/autoplace_pipes.lua
+++ b/autoplace_pipes.lua
@@ -211,7 +211,7 @@ function pipeworks.scan_pipe_surroundings(pos)
 		pzm = 1
 	end
 
-	print("stage 2 returns "..pxm+8*pxp+2*pym+16*pyp+4*pzm+32*pzp..
+	minetest.log("info", "stage 2 returns "..pxm+8*pxp+2*pym+16*pyp+4*pzm+32*pzp..
 		" for nodes surrounding "..minetest.get_node(pos).name.." at "..minetest.pos_to_string(pos))
 	return pxm+8*pxp+2*pym+16*pyp+4*pzm+32*pzp
 end

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -31,7 +31,7 @@ local settings = {
 	delete_item_on_clearobject = true,
 	use_real_entities = true,
 	entity_update_interval = 0,
-	lua_tube_print_behavior = "noop",
+	lua_tube_print_behavior = "log",
 }
 
 pipeworks.toggles = {}

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -70,7 +70,6 @@ for name, value in pairs(settings) do
 	elseif setting_type == "number" then
 		pipeworks[name] = tonumber(minetest.settings:get(prefix..name) or value)
 	else
-		local got_setting = minetest.settings:get(prefix..name)
-		pipeworks[name] = got_setting ~= "" and got_setting or value
+		pipeworks[name] = value
 	end
 end

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -31,6 +31,7 @@ local settings = {
 	delete_item_on_clearobject = true,
 	use_real_entities = true,
 	entity_update_interval = 0,
+	lua_tube_print_behavior = "noop",
 }
 
 pipeworks.toggles = {}
@@ -70,6 +71,7 @@ for name, value in pairs(settings) do
 	elseif setting_type == "number" then
 		pipeworks[name] = tonumber(minetest.settings:get(prefix..name) or value)
 	else
-		pipeworks[name] = value
+		local got_setting = minetest.settings:get(prefix..name)
+		pipeworks[name] = got_setting ~= "" and got_setting or value
 	end
 end

--- a/default_settings.lua
+++ b/default_settings.lua
@@ -31,7 +31,6 @@ local settings = {
 	delete_item_on_clearobject = true,
 	use_real_entities = true,
 	entity_update_interval = 0,
-	lua_tube_print_behavior = "log",
 }
 
 pipeworks.toggles = {}

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -87,3 +87,7 @@ pipeworks_entity_update_interval (Entity Update Interval) float 0 0 0.8
 
 # if set to true, items passing through teleport tubes will log log where they came from and where they went.
 pipeworks_log_teleport_tubes (Log Teleport Tubes) bool false
+
+# Behavior of print() inside a lua tube. By default, this emits a message into actionstream.
+# Set it to noop if you wish to disable that behavior.
+pipeworks_lua_tube_print_behavior (Behavior of print in Lua Tube) enum log log,noop

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -229,7 +229,7 @@ end
 -------------------------
 
 local function safe_print(param)
-	if minetest.settings:get("pipeworks_lua_tube_print_behavior") == "log" then
+	if (minetest.settings:get("pipeworks_lua_tube_print_behavior") or "log") == "log" then
 		local string_meta = getmetatable("")
 		local sandbox = string_meta.__index
 		string_meta.__index = string -- Leave string sandbox temporarily

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -232,7 +232,7 @@ local function safe_print(param)
 	local string_meta = getmetatable("")
 	local sandbox = string_meta.__index
 	string_meta.__index = string -- Leave string sandbox temporarily
-	print(dump(param))
+	minetest.log("action", "Lua Tube print: " .. dump(param))
 	string_meta.__index = sandbox -- Restore string sandbox
 end
 
@@ -603,7 +603,7 @@ local function save_memory(pos, meta, mem)
 		meta:set_string("lc_memory", memstring)
 		meta:mark_as_private("lc_memory")
 	else
-		print("Error: lua_tube memory overflow. "..memsize_max.." bytes available, "
+		minetest.log("error", "lua_tube memory overflow. "..memsize_max.." bytes available, "
 				..#memstring.." required. Controller overheats.")
 		burn_controller(pos)
 	end

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -229,7 +229,7 @@ end
 -------------------------
 
 local function safe_print(param)
-	if pipeworks.lua_tube_print_behavior == "log" then
+	if minetest.settings:get("pipeworks_lua_tube_print_behavior") == "log" then
 		local string_meta = getmetatable("")
 		local sandbox = string_meta.__index
 		string_meta.__index = string -- Leave string sandbox temporarily

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -232,7 +232,7 @@ local function safe_print(param)
 	local string_meta = getmetatable("")
 	local sandbox = string_meta.__index
 	string_meta.__index = string -- Leave string sandbox temporarily
-	minetest.log("action", "Lua Tube print: " .. dump(param))
+	print(dump(param))
 	string_meta.__index = sandbox -- Restore string sandbox
 end
 

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -228,9 +228,8 @@ end
 -- Parsing and running --
 -------------------------
 
-local safe_print = function() end
-if pipeworks.lua_tube_print_behavior == "log" then
-	safe_print = function(param)
+local function safe_print(param)
+	if pipeworks.lua_tube_print_behavior == "log" then
 		local string_meta = getmetatable("")
 		local sandbox = string_meta.__index
 		string_meta.__index = string -- Leave string sandbox temporarily

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -606,7 +606,7 @@ local function save_memory(pos, meta, mem)
 		meta:set_string("lc_memory", memstring)
 		meta:mark_as_private("lc_memory")
 	else
-		minetest.log("error", "lua_tube memory overflow. "..memsize_max.." bytes available, "
+		minetest.log("info", "lua_tube memory overflow. "..memsize_max.." bytes available, "
 				..#memstring.." required. Controller overheats.")
 		burn_controller(pos)
 	end

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -229,11 +229,13 @@ end
 -------------------------
 
 local function safe_print(param)
-	local string_meta = getmetatable("")
-	local sandbox = string_meta.__index
-	string_meta.__index = string -- Leave string sandbox temporarily
-	print(dump(param))
-	string_meta.__index = sandbox -- Restore string sandbox
+	if mesecon.setting("luacontroller_print_behavior", "log") == "log" then
+		local string_meta = getmetatable("")
+		local sandbox = string_meta.__index
+		string_meta.__index = string -- Leave string sandbox temporarily
+		minetest.log("action", string.format("[pipeworks.tubes.lua] print(%s)", dump(param)))
+		string_meta.__index = sandbox -- Restore string sandbox
+	end
 end
 
 local function safe_date()

--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -228,8 +228,9 @@ end
 -- Parsing and running --
 -------------------------
 
-local function safe_print(param)
-	if mesecon.setting("luacontroller_print_behavior", "log") == "log" then
+local safe_print = function() end
+if pipeworks.lua_tube_print_behavior == "log" then
+	safe_print = function(param)
 		local string_meta = getmetatable("")
 		local sandbox = string_meta.__index
 		string_meta.__index = string -- Leave string sandbox temporarily

--- a/wielder.lua
+++ b/wielder.lua
@@ -281,7 +281,6 @@ if pipeworks.enable_node_breaker then
 				-- Don't mechanically wear out tool
 				if stack:get_wear() ~= old_stack:get_wear() and stack:get_count() == old_stack:get_count()
 						and (item_def.wear_represents == nil or item_def.wear_represents == "mechanical_wear") then
-					print("replaced")
 					fakeplayer:set_wielded_item(old_stack)
 				end
 			elseif not stack:is_empty() then


### PR DESCRIPTION
This PR gets rid of `print()` calls by either removing them or changing them into appropriate `minetest.log` calls. This PR is ready for review.