### PR TITLE
Change autocrafter button sizes (for Russian)

### DIFF
--- a/autocrafter.lua
+++ b/autocrafter.lua
@@ -392,8 +392,8 @@ local function update_meta(meta, enabled)
 	if core.get_modpath("digilines") then
 		fs = fs .. "field[0.22,4.1;4.5,0.75;channel;" .. S("Channel") ..
 			";${channel}]" ..
-			"button[5,4.1;1.5,0.75;set_channel;" .. S("Set") .. "]" ..
-			"button_exit[6.8,4.1;2,0.75;close;" .. S("Close") .. "]"
+			"button[5,4.1;2,0.75;set_channel;" .. S("Set") .. "]" ..
+			"button_exit[7.2,4.1;2,0.75;close;" .. S("Close") .. "]"
 	end
 	meta:set_string("formspec", fs)
 


### PR DESCRIPTION
Good time! Corrects the size of the buttons, the text did not fit (in Russian).
Was
<img width="584" height="270" alt="2025-07-29_12-19" src="https://github.com/user-attachments/assets/21f3b7e1-fba6-4892-9726-e30fc42e960e" />
This PR
<img width="590" height="423" alt="2025-07-29_12-26" src="https://github.com/user-attachments/assets/98d5f256-f6f0-409c-9902-dc18f01fda23" />

