### PR TITLE
Fix missing arrows on lua_tube yellow port

### DIFF
--- a/tubes/lua.lua
+++ b/tubes/lua.lua
@@ -852,8 +852,8 @@ for white  = 0, 1 do
 	tiles[5] = tiles[5]..tiles_on_off.R_90:format(blue == 1 and "on" or "off");
 	tiles[6] = tiles[6]..tiles_on_off.R270:format(blue == 1 and "on" or "off");
 	-- Yellow
-	tiles[1] = tiles[1]..tiles_on_off.R180:format(yellow == 1 and "on" or "off");
-	tiles[2] = tiles[2]..tiles_on_off.R180:format(yellow == 1 and "on" or "off");
+	tiles[3] = tiles[3]..tiles_on_off.R180:format(yellow == 1 and "on" or "off");
+	tiles[4] = tiles[4]..tiles_on_off.R180:format(yellow == 1 and "on" or "off");
 	tiles[5] = tiles[5]..tiles_on_off.R180:format(yellow == 1 and "on" or "off");
 	tiles[6] = tiles[6]..tiles_on_off.R180:format(yellow == 1 and "on" or "off");
 	-- Green


### PR DESCRIPTION
The controller tube (`lua_tube`) had missing arrows on the west and east sides of its yellow port. This PR fixes it.
<img width="782" height="470" alt="lua_tube_arrows" src="https://github.com/user-attachments/assets/1e5da03b-abbb-479a-b7ad-8125f3dd0f60" />
