### PR TITLE
Add an optional dependency on DevTest's mapgen mod

### DIFF
--- a/mod.conf
+++ b/mod.conf
@@ -1,5 +1,5 @@
 name = pipeworks
 description = This mod uses mesh nodes and nodeboxes to supply a complete set of 3D pipes and tubes, along with devices that work with them.
 depends = basic_materials, xcompat, fakelib
-optional_depends = mesecons, mesecons_mvps, digilines, signs_lib, unified_inventory, default, screwdriver, fl_mapgen, sound_api, i3, hades_core, hades_furnaces, hades_chests, mcl_mapgen_core, mcl_barrels, mcl_furnaces, mcl_experience, vizlib
+optional_depends = mesecons, mesecons_mvps, digilines, signs_lib, unified_inventory, default, screwdriver, fl_mapgen, sound_api, i3, hades_core, hades_furnaces, hades_chests, mcl_mapgen_core, mcl_barrels, mcl_furnaces, mcl_experience, vizlib, mapgen
 min_minetest_version = 5.5.0


### PR DESCRIPTION
Addresses #173
By depending on mapgen, we make sure that Pipeworks loads after the required aliases are defined.

The name feels pretty common though and i don't know how to make sure that the considered mapgen mod is from DevTest. I found no mod named “mapgen” on ContentDB, so one may pop one day. Or is there something preventing it?