### PR TITLE
fix misnamed setting

### DIFF
--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -91,7 +91,7 @@ pipeworks_entity_update_interval (Entity Update Interval) float 0 0 0.8
 # This breaks expected behavior with digiline conducting tubes.
 # If disabled, the devices will not be able to send or recieve digiline signals from the top
 # or bottom faces, regardless of the node rotation.
-enable_vertical_digilines_connectivity (Use the default rules from the digilines mod) bool false
+pipeworks_enable_vertical_digilines_connectivity (Use the default rules from the digilines mod) bool false
 
 # if set to true, items passing through teleport tubes will log log where they came from and where they went.
 pipeworks_log_teleport_tubes (Log Teleport Tubes) bool false


### PR DESCRIPTION
missing prefix in settingtypes.txt
https://github.com/mt-mods/pipeworks/blob/2cb3d74d360c77a907e1eb99fc1749a11ca83882/default_settings.lua#L70