### PR TITLE
Make tp tubes use mod storage with prefixed keys

### DIFF
--- a/tubes/teleport.lua
+++ b/tubes/teleport.lua
@@ -2,6 +2,7 @@
 local S = core.get_translator("pipeworks")
 local filename = core.get_worldpath().."/teleport_tubes"  -- Only used for backward-compat
 local storage = core.get_mod_storage()
+local STORAGE_PREFIX = "tptube_"
 
 local enable_logging = core.settings:get_bool("pipeworks_log_teleport_tubes", false)
 
@@ -36,17 +37,19 @@ end
 
 local function save_tube_db()
 	receiver_cache = {}
-	local fields = {version = tube_db_version}
+	storage:set_string("version", "") -- cleanup prefix-less entry
+	storage:set_int(STORAGE_PREFIX.."version", tube_db_version)
 	for key, val in pairs(tube_db) do
-		fields[key] = serialize_tube(val)
+		storage:set_string(key, "")
+		storage:set_string(STORAGE_PREFIX..key, serialize_tube(val))
 	end
-	storage:from_table({fields = fields})
 end
 
 local function save_tube(hash)
 	local tube = tube_db[hash]
 	receiver_cache[tube.channel] = nil
-	storage:set_string(hash, serialize_tube(tube))
+	storage:set_string(hash, "") -- cleanup prefix-less entry
+	storage:set_string(STORAGE_PREFIX..hash, serialize_tube(tube))
 end
 
 local function remove_tube(pos)
@@ -55,6 +58,7 @@ local function remove_tube(pos)
 		receiver_cache[tube_db[hash].channel] = nil
 		tube_db[hash] = nil
 		storage:set_string(hash, "")
+		storage:set_string(STORAGE_PREFIX..hash, "")
 	end
 end
 
@@ -93,17 +97,35 @@ local function migrate_tube_db()
 end
 
 local function read_tube_db()
-	local version = storage:get_int("version")
-	if version < tube_db_version then
-		migrate_tube_db()
-	elseif version > tube_db_version then
-		error("Cannot read teleport tube database of version "..version)
-	else
+	local version = storage:get_int(STORAGE_PREFIX.."version")
+	if version ~= 0 then
+		-- storage with prefix
 		for key, val in pairs(storage:to_table().fields) do
-			if tonumber(key) then
-				tube_db[key] = deserialize_tube(key, val)
-			elseif key ~= "version" then
-				error("Unknown field in teleport tube database: "..key)
+			local short_key = string.match(key, "^"..STORAGE_PREFIX.."(.+)")
+			if short_key then -- only handle keys relevant to tp tubes
+				if tonumber(short_key) then
+					tube_db[short_key] = deserialize_tube(short_key, val)
+				elseif short_key ~= "version" then
+					error("Unknown field in teleport tube database: "..key)
+				end
+			end
+		end
+	else
+		-- legacy, prefix-less storage
+		version = storage:get_int("version")
+		if version < tube_db_version then
+			-- we also get here if no version number was found,
+			-- e.g. on a fresh new world
+			migrate_tube_db()
+		elseif version > tube_db_version then
+			error("Cannot read teleport tube database of version "..version)
+		else
+			for key, val in pairs(storage:to_table().fields) do
+				if tonumber(key) then
+					tube_db[key] = deserialize_tube(key, val)
+				elseif key ~= "version" then
+					error("Unknown field in teleport tube database: "..key)
+				end
 			end
 		end
 	end

--- a/tubes/teleport.lua
+++ b/tubes/teleport.lua
@@ -41,14 +41,20 @@ local function save_tube_db()
 	storage:set_int(STORAGE_PREFIX.."version", tube_db_version)
 	for key, val in pairs(tube_db) do
 		storage:set_string(key, "")
-		storage:set_string(STORAGE_PREFIX..key, serialize_tube(val))
+		storage:set_string(
+			string.format("%s%.0f", STORAGE_PREFIX, key),
+			serialize_tube(val)
+		)
 	end
 end
 
 local function save_tube(hash)
 	local tube = tube_db[hash]
 	receiver_cache[tube.channel] = nil
-	storage:set_string(STORAGE_PREFIX..hash, serialize_tube(tube))
+	storage:set_string(
+		string.format("%s%.0f", STORAGE_PREFIX, hash),
+		serialize_tube(tube)
+	)
 end
 
 local function remove_tube(pos)
@@ -56,7 +62,7 @@ local function remove_tube(pos)
 	if tube_db[hash] then
 		receiver_cache[tube_db[hash].channel] = nil
 		tube_db[hash] = nil
-		storage:set_string(STORAGE_PREFIX..hash, "")
+		storage:set_string(string.format("%s%.0f", STORAGE_PREFIX, hash), "")
 	end
 end
 


### PR DESCRIPTION
Change every call to `storage:*` to use prefixed keys. Also cleans up previous prefix-less keys upon migrating.
It is worth noting that this might inadvertently erase keys set by other parts of Pipeworks if those keys happen to match the position hash of an existing teleport tube. But I assume that it won't happen, because I trust that nobody will use prefix-less keys in future extensions of Pipeworks.

Fixes #177.